### PR TITLE
Find plans using name and alternative system ids

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  aws_table_name: 'plans',
+  aws_local_config: {
+    region: 'local',
+    endpoint: 'http://localhost:8000'
+  },
+  aws_remote_config: {}
+};

--- a/config/tables/plans.json
+++ b/config/tables/plans.json
@@ -5,10 +5,7 @@
     { "AttributeName": "id", "AttributeType": "S" },
     { "AttributeName": "lastName", "AttributeType": "S" }
   ],
-  "ProvisionedThroughput": {
-    "ReadCapacityUnits": 4,
-    "WriteCapacityUnits": 4
-  },
+  "BillingMode": "PAY_PER_REQUEST",
   "GlobalSecondaryIndexes": [
     {
       "IndexName": "name_idx",
@@ -16,14 +13,15 @@
         {
           "AttributeName": "lastName",
           "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "firstName",
+          "KeyType": "RANGE"
         }
       ],
       "Projection": {
-        "ProjectionType": "ALL"
-      },
-      "ProvisionedThroughput": {
-        "ReadCapacityUnits": 8,
-        "WriteCapacityUnits": 4
+        "ProjectionType": "INCLUDE",
+        "NonKeyAttributes": "id"
       }
     }
   ]

--- a/config/tables/plans.json
+++ b/config/tables/plans.json
@@ -3,7 +3,8 @@
   "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
   "AttributeDefinitions": [
     { "AttributeName": "id", "AttributeType": "S" },
-    { "AttributeName": "lastName", "AttributeType": "S" }
+    { "AttributeName": "queryLastName", "AttributeType": "S" },
+    { "AttributeName": "queryFirstName", "AttributeType": "S" }
   ],
   "BillingMode": "PAY_PER_REQUEST",
   "GlobalSecondaryIndexes": [
@@ -11,11 +12,11 @@
       "IndexName": "name_idx",
       "KeySchema": [
         {
-          "AttributeName": "lastName",
+          "AttributeName": "queryLastName",
           "KeyType": "HASH"
         },
         {
-          "AttributeName": "firstName",
+          "AttributeName": "queryFirstName",
           "KeyType": "RANGE"
         }
       ],

--- a/config/tables/plans.json
+++ b/config/tables/plans.json
@@ -21,7 +21,7 @@
       ],
       "Projection": {
         "ProjectionType": "INCLUDE",
-        "NonKeyAttributes": "id"
+        "NonKeyAttributes": "id,systemIds"
       }
     }
   ]

--- a/config/tables/plans.json
+++ b/config/tables/plans.json
@@ -1,0 +1,30 @@
+{
+  "TableName": "plans",
+  "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+  "AttributeDefinitions": [
+    { "AttributeName": "id", "AttributeType": "S" },
+    { "AttributeName": "lastName", "AttributeType": "S" }
+  ],
+  "ProvisionedThroughput": {
+    "ReadCapacityUnits": 4,
+    "WriteCapacityUnits": 4
+  },
+  "GlobalSecondaryIndexes": [
+    {
+      "IndexName": "name_idx",
+      "KeySchema": [
+        {
+          "AttributeName": "lastName",
+          "KeyType": "HASH"
+        }
+      ],
+      "Projection": {
+        "ProjectionType": "ALL"
+      },
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 8,
+        "WriteCapacityUnits": 4
+      }
+    }
+  ]
+}

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -10,8 +10,11 @@ const config = {
   secretAccessKey: 'bar'
 };
 
-const client = new AWS.DynamoDB.DocumentClient({ config });
-const planGateway = new PlanGateway({ client });
+const planGateway = new PlanGateway({
+  client: new AWS.DynamoDB.DocumentClient({ config }),
+  tableName: process.env.PLANS_TABLE_NAME
+});
+
 const getPlan = new GetPlan({ planGateway });
 const createPlan = new CreatePlan({ planGateway });
 

--- a/lib/domain/plan.js
+++ b/lib/domain/plan.js
@@ -1,8 +1,9 @@
 export default class Plan {
-  constructor({ id, created, firstName, lastName }) {
+  constructor({ id, created, firstName, lastName, systemIds }) {
     this.id = id;
     this.created = created;
     this.firstName = firstName;
     this.lastName = lastName;
+    this.systemIds = systemIds || [];
   }
 }

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -1,11 +1,12 @@
 import { nanoid } from 'nanoid';
 import { ArgumentError, Plan } from '../domain';
+import { normalise } from '../utils/normalise';
 
 function toDynamoModel(plan) {
   return {
     ...plan,
-    queryFirstName: plan.firstName.toLowerCase(),
-    queryLastName: plan.lastName.toLowerCase()
+    queryFirstName: normalise(plan.firstName),
+    queryLastName: normalise(plan.lastName)
   };
 }
 

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -14,9 +14,9 @@ function fromDynamoModel(model) {
 }
 
 export default class PlanGateway {
-  constructor({ client }) {
+  constructor({ client, tableName }) {
     this.client = client;
-    this.tableName = 'plans';
+    this.tableName = tableName;
   }
 
   async create({ firstName, lastName, systemIds }) {

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -1,30 +1,43 @@
 import { nanoid } from 'nanoid';
 import { ArgumentError, Plan } from '../domain';
 
+function toDynamoModel(plan) {
+  return {
+    ...plan,
+    queryFirstName: plan.firstName.toLowerCase(),
+    queryLastName: plan.lastName.toLowerCase()
+  };
+}
+
+function fromDynamoModel(model) {
+  return new Plan(model);
+}
+
 export default class PlanGateway {
   constructor({ client }) {
     this.client = client;
     this.tableName = 'plans';
   }
 
-  async create({ firstName, lastName }) {
+  async create({ firstName, lastName, systemIds }) {
     if (!firstName) throw new ArgumentError('first name cannot be null.');
     if (!lastName) throw new ArgumentError('last name cannot be null.');
 
-    const id = nanoid(20);
+    const plan = new Plan({
+      id: nanoid(20),
+      created: new Date(Date.now()).toISOString(),
+      firstName,
+      lastName,
+      systemIds: systemIds
+    });
 
     const request = {
       TableName: this.tableName,
-      Item: {
-        id,
-        created: new Date(Date.now()).toISOString(),
-        firstName,
-        lastName
-      }
+      Item: toDynamoModel(plan)
     };
 
     const result = await this.client.put(request).promise();
-    return new Plan(result.Items[0]);
+    return fromDynamoModel(result.Items[0]);
   }
 
   async get({ id }) {
@@ -40,10 +53,10 @@ export default class PlanGateway {
 
     const result = await this.client.query(request).promise();
     if (result.Items.length === 0) return null;
-    return new Plan(result.Items[0]);
+    return fromDynamoModel(result.Items[0]);
   }
 
-  async find({ firstName, lastName, systemIds }) {
+  async find({ firstName, lastName, systemIds = [] }) {
     if (!firstName) throw new Error('first name cannot be null.');
     if (!lastName) throw new Error('last name cannot be null.');
 
@@ -51,7 +64,10 @@ export default class PlanGateway {
       TableName: this.tableName,
       IndexName: 'name_idx',
       KeyConditionExpression: 'lastName = :l and firstName = :f',
-      ExpressionAttributeValues: { ':l': lastName, ':f': firstName }
+      ExpressionAttributeValues: {
+        ':l': lastName.toLowerCase(),
+        ':f': firstName.toLowerCase()
+      }
     };
 
     const { Items } = await this.client.query(request).promise();

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -42,4 +42,27 @@ export default class PlanGateway {
     if (result.Items.length === 0) return null;
     return new Plan(result.Items[0]);
   }
+
+  async find({ firstName, lastName, systemIds }) {
+    // TODO: decide what the ProjectionType attributes need to be in the plans schema
+    // see /config/tables/plans.json
+    // We'll only want to return the attributes used for filtering when searching by
+    // lastName and not all the actual plan data
+
+    if (!firstName) throw new Error('first name cannot be null.');
+    if (!lastName) throw new Error('last name cannot be null.');
+
+    const request = {
+      TableName: this.tableName,
+      IndexName: 'name_idx',
+      KeyConditionExpression: 'lastName = :l',
+      ExpressionAttributeValues: { ':l': lastName }
+    };
+
+    const result = await this.client.query(request).promise();
+
+    // filter the systemIds here
+
+    return result.Items.filter(item => item.firstName === firstName);
+  }
 }

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -44,26 +44,26 @@ export default class PlanGateway {
   }
 
   async find({ firstName, lastName, systemIds }) {
-    // TODO: decide what the ProjectionType attributes need to be in the plans schema
-    // see /config/tables/plans.json
-    // We'll only want to return the attributes used for filtering when searching by
-    // lastName and not all the actual plan data
-
     if (!firstName) throw new Error('first name cannot be null.');
     if (!lastName) throw new Error('last name cannot be null.');
 
     const request = {
       TableName: this.tableName,
       IndexName: 'name_idx',
-      KeyConditionExpression: 'lastName = :l',
-      FilterExpression: 'firstName = :f',
-      ExpressionAttributeValues: { ':f': firstName, ':l': lastName }
+      KeyConditionExpression: 'lastName = :l and firstName = :f',
+      ExpressionAttributeValues: { ':l': lastName, ':f': firstName }
     };
 
-    const result = await this.client.query(request).promise();
+    const { Items } = await this.client.query(request).promise();
 
-    // filter the systemIds here
+    return Promise.all(
+      Items.filter(match => {
+        if (!match.systemIds || match.systemIds.length === 0) {
+          return true;
+        }
 
-    return result.Items;
+        return match.systemIds.some(id => systemIds.includes(id));
+      }).map(match => this.get(match))
+    );
   }
 }

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -56,13 +56,14 @@ export default class PlanGateway {
       TableName: this.tableName,
       IndexName: 'name_idx',
       KeyConditionExpression: 'lastName = :l',
-      ExpressionAttributeValues: { ':l': lastName }
+      FilterExpression: 'firstName = :f',
+      ExpressionAttributeValues: { ':f': firstName, ':l': lastName }
     };
 
     const result = await this.client.query(request).promise();
 
     // filter the systemIds here
 
-    return result.Items.filter(item => item.firstName === firstName);
+    return result.Items;
   }
 }

--- a/lib/use-cases/findPlans.js
+++ b/lib/use-cases/findPlans.js
@@ -3,8 +3,7 @@ export default class FindPlans {
     this.planGateway = planGateway;
   }
 
-  async execute(metadata) {
-    const plans = await this.planGateway.find(metadata);
-    return [];
+  async execute(request) {
+    return await this.planGateway.find(request);
   }
 }

--- a/lib/use-cases/findPlans.js
+++ b/lib/use-cases/findPlans.js
@@ -1,0 +1,10 @@
+export default class FindPlans {
+  constructor({ planGateway }) {
+    this.planGateway = planGateway;
+  }
+
+  async execute(metadata) {
+    const plans = await this.planGateway.find(metadata);
+    return [];
+  }
+}

--- a/lib/utils/normalise.js
+++ b/lib/utils/normalise.js
@@ -1,0 +1,13 @@
+/**
+ * Normalises a string for comparison, including removing any
+ * diacritics from the input to account for bad data entry or
+ * input from systems where only ASCII is allowed.
+ * @see https://stackoverflow.com/a/37511463
+ * @param {string} string the string to normalise
+ */
+export function normalise(string) {
+  return string
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u{0300}-\u{036e}]/gu, '');
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "aws-sdk": "^2.669.0",
     "@babel/preset-react": "^7.9.4",
+    "@babel/plugin-transform-runtime": "^7.9.6",
     "@babel/runtime": "^7.9.6",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -127,7 +127,7 @@ describe('Plan Gateway', () => {
       expect(client.query).not.toHaveBeenCalled();
     });
 
-    it('can find matching plans when first name and last name match', async () => {
+    it('can find matching plans', async () => {
       const customerData = {
         firstName: 'Barry',
         lastName: 'Jones'
@@ -139,7 +139,11 @@ describe('Plan Gateway', () => {
         TableName,
         IndexName: 'name_idx',
         KeyConditionExpression: 'lastName = :l',
-        ExpressionAttributeValues: { ':l': customerData.lastName }
+        FilterExpression: 'firstName = :f',
+        ExpressionAttributeValues: {
+          ':f': customerData.firstName,
+          ':l': customerData.lastName
+        }
       };
       const planGateway = new PlanGateway({ client });
 
@@ -149,22 +153,15 @@ describe('Plan Gateway', () => {
       expect(result).toEqual([customerData]);
     });
 
-    it('cant find matching plans when only the last name matches', async () => {
+    it('returns empty array when no matching plans', async () => {
       client.query = jest.fn(() => ({
-        promise: jest.fn(() => ({
-          Items: [
-            {
-              firstName: 'Jane',
-              lastName: 'Brown'
-            }
-          ]
-        }))
+        promise: jest.fn(() => ({ Items: [] }))
       }));
       const planGateway = new PlanGateway({ client });
 
       const result = await planGateway.find({
-        firstName: 'Sarah',
-        lastName: 'Brown'
+        firstName: 'Janos',
+        lastName: 'Manos'
       });
 
       expect(result).toEqual([]);

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -156,7 +156,9 @@ describe('Plan Gateway', () => {
       });
 
       expect(client.query).toHaveBeenCalledWith(expectedRequest);
-      expect(result).toEqual([customerData]);
+      expect(result).toStrictEqual(
+        expect.arrayContaining([expect.objectContaining(customerData)])
+      );
     });
 
     it('filters plans using system ids', async () => {
@@ -199,7 +201,9 @@ describe('Plan Gateway', () => {
 
       const planGateway = new PlanGateway({ client });
       const result = await planGateway.find(customerData);
-      expect(result).toEqual([customerData]);
+      expect(result).toStrictEqual(
+        expect.arrayContaining([expect.objectContaining(customerData)])
+      );
     });
 
     it('returns empty array when no matching plans', async () => {

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -39,12 +39,15 @@ describe('Plan Gateway', () => {
     it('can create a plan', async () => {
       const firstName = 'Trevor';
       const lastName = 'McLevor';
+
       const expectedRequest = {
         TableName,
         Item: expect.objectContaining({
           id: expect.any(String),
           firstName,
-          lastName
+          lastName,
+          queryFirstName: firstName.toLowerCase(),
+          queryLastName: lastName.toLowerCase()
         })
       };
       const planGateway = new PlanGateway({ client });
@@ -143,8 +146,8 @@ describe('Plan Gateway', () => {
         IndexName: 'name_idx',
         KeyConditionExpression: 'lastName = :l and firstName = :f',
         ExpressionAttributeValues: {
-          ':f': customerData.firstName,
-          ':l': customerData.lastName
+          ':f': customerData.firstName.toLowerCase(),
+          ':l': customerData.lastName.toLowerCase()
         }
       };
 

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -107,4 +107,67 @@ describe('Plan Gateway', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('find', () => {
+    it('throws an error if first name is missing', async () => {
+      const planGateway = new PlanGateway({ client });
+
+      await expect(async () => {
+        await planGateway.find({});
+      }).rejects.toThrow('first name cannot be null.');
+      expect(client.query).not.toHaveBeenCalled();
+    });
+
+    it('throws an error if last name is missing', async () => {
+      const planGateway = new PlanGateway({ client });
+
+      await expect(async () => {
+        await planGateway.find({ firstName: 'Linda' });
+      }).rejects.toThrow('last name cannot be null.');
+      expect(client.query).not.toHaveBeenCalled();
+    });
+
+    it('can find matching plans when first name and last name match', async () => {
+      const customerData = {
+        firstName: 'Barry',
+        lastName: 'Jones'
+      };
+      client.query = jest.fn(() => ({
+        promise: jest.fn(() => ({ Items: [customerData] }))
+      }));
+      const expectedRequest = {
+        TableName,
+        IndexName: 'name_idx',
+        KeyConditionExpression: 'lastName = :l',
+        ExpressionAttributeValues: { ':l': customerData.lastName }
+      };
+      const planGateway = new PlanGateway({ client });
+
+      const result = await planGateway.find(customerData);
+
+      expect(client.query).toHaveBeenCalledWith(expectedRequest);
+      expect(result).toEqual([customerData]);
+    });
+
+    it('cant find matching plans when only the last name matches', async () => {
+      client.query = jest.fn(() => ({
+        promise: jest.fn(() => ({
+          Items: [
+            {
+              firstName: 'Jane',
+              lastName: 'Brown'
+            }
+          ]
+        }))
+      }));
+      const planGateway = new PlanGateway({ client });
+
+      const result = await planGateway.find({
+        firstName: 'Sarah',
+        lastName: 'Brown'
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -3,6 +3,7 @@ import { ArgumentError, Plan } from '../../../lib/domain';
 
 describe('Plan Gateway', () => {
   let client;
+  const tableName = 'plans';
 
   beforeEach(() => {
     client = {
@@ -13,11 +14,9 @@ describe('Plan Gateway', () => {
     };
   });
 
-  const TableName = 'plans';
-
   describe('create', () => {
     it('throws an error if firstName is not provided', async () => {
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       await expect(async () => {
         await planGateway.create({ lastName: 'name' });
@@ -41,7 +40,7 @@ describe('Plan Gateway', () => {
       const lastName = 'McLevor';
 
       const expectedRequest = {
-        TableName,
+        TableName: tableName,
         Item: expect.objectContaining({
           id: expect.any(String),
           firstName,
@@ -50,7 +49,7 @@ describe('Plan Gateway', () => {
           queryLastName: lastName.toLowerCase()
         })
       };
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       const result = await planGateway.create({ firstName, lastName });
 
@@ -65,7 +64,7 @@ describe('Plan Gateway', () => {
 
   describe('get', () => {
     it('throws an error if id is null', async () => {
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       await expect(async () => {
         await planGateway.get({ id: null });
@@ -82,13 +81,13 @@ describe('Plan Gateway', () => {
         promise: jest.fn(() => ({ Items: [{ id, firstName, lastName }] }))
       }));
       const expectedRequest = {
-        TableName,
+        TableName: tableName,
         KeyConditionExpression: 'id = :id',
         ExpressionAttributeValues: {
           ':id': id
         }
       };
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       const result = await planGateway.get({ id });
 
@@ -103,7 +102,7 @@ describe('Plan Gateway', () => {
       client.query = jest.fn(() => ({
         promise: jest.fn(() => ({ Items: [] }))
       }));
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       const result = await planGateway.get({ id: 1 });
 
@@ -113,7 +112,7 @@ describe('Plan Gateway', () => {
 
   describe('find', () => {
     it('throws an error if first name is missing', async () => {
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       await expect(async () => {
         await planGateway.find({});
@@ -122,7 +121,7 @@ describe('Plan Gateway', () => {
     });
 
     it('throws an error if last name is missing', async () => {
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       await expect(async () => {
         await planGateway.find({ firstName: 'Linda' });
@@ -142,7 +141,7 @@ describe('Plan Gateway', () => {
       }));
 
       const expectedRequest = {
-        TableName,
+        TableName: tableName,
         IndexName: 'name_idx',
         KeyConditionExpression: 'lastName = :l and firstName = :f',
         ExpressionAttributeValues: {
@@ -151,7 +150,7 @@ describe('Plan Gateway', () => {
         }
       };
 
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       const result = await planGateway.find({
         firstName: customerData.firstName,
@@ -202,7 +201,7 @@ describe('Plan Gateway', () => {
         };
       });
 
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
       const result = await planGateway.find(customerData);
       expect(result).toStrictEqual(
         expect.arrayContaining([expect.objectContaining(customerData)])
@@ -213,7 +212,7 @@ describe('Plan Gateway', () => {
       client.query = jest.fn(() => ({
         promise: jest.fn(() => ({ Items: [] }))
       }));
-      const planGateway = new PlanGateway({ client });
+      const planGateway = new PlanGateway({ client, tableName });
 
       const result = await planGateway.find({
         firstName: 'Janos',

--- a/test/unit/utils/normalise.test.js
+++ b/test/unit/utils/normalise.test.js
@@ -1,0 +1,11 @@
+import { normalise } from '../../../lib/utils/normalise';
+
+describe('normalise', () => {
+  it('normalises strings, including diacritics', () => {
+    expect(normalise('Crème Brulée')).toBe('creme brulee');
+    expect(normalise('Andreí')).toBe('andrei');
+    expect(normalise('Amélie')).toBe('amelie');
+    expect(normalise('François-Xavier')).toBe('francois-xavier');
+    expect(normalise('Steve')).toBe('steve');
+  });
+});

--- a/test/use-cases/findPlans.test.js
+++ b/test/use-cases/findPlans.test.js
@@ -1,15 +1,17 @@
 import FindPlans from '../../lib/use-cases/findPlans';
 
-describe('FindPlans', () => {
+describe('Find plans', () => {
   it('can find matching plans', async () => {
-    const planGateway = {
-      find: jest.fn()
-    };
+    const planGateway = { find: jest.fn() };
     const findPlans = new FindPlans({ planGateway });
-    const metadata = { firstName: 'Joe', lastName: 'Bro', systemId: '123' };
 
-    await findPlans.execute(metadata);
+    const findPlansRequest = {
+      firstName: 'Joe',
+      lastName: 'Bro',
+      systemIds: ['123']
+    };
 
-    expect(planGateway.find).toHaveBeenCalledWith(metadata);
+    await findPlans.execute(findPlansRequest);
+    expect(planGateway.find).toHaveBeenCalledWith(findPlansRequest);
   });
 });

--- a/test/use-cases/findPlans.test.js
+++ b/test/use-cases/findPlans.test.js
@@ -1,0 +1,15 @@
+import FindPlans from '../../lib/use-cases/findPlans';
+
+describe('FindPlans', () => {
+  it('can find matching plans', async () => {
+    const planGateway = {
+      find: jest.fn()
+    };
+    const findPlans = new FindPlans({ planGateway });
+    const metadata = { firstName: 'Joe', lastName: 'Bro', systemId: '123' };
+
+    await findPlans.execute(metadata);
+
+    expect(planGateway.find).toHaveBeenCalledWith(metadata);
+  });
+});


### PR DESCRIPTION
Supports finding a plan using name and an optional list of system ids, out of which at least one of them should match the system ids stored against the plan. Name is not case sensitive.

If no `systemIds` are stored against the plan then only the name is required to match.

 - Adds a global secondary index on `queryLastName`, with sort key of `queryFirstName`.
 - Switched billing mode to `PAY_PER_REQUEST` to avoid running with excess DynamoDB capacity.
 - Updates `PlanGateway` to accept table name in it's constructor so that the table name is configurable.