### PR TITLE
Adds plans DynamoDB table to serverless.yml

### DIFF
--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -63,7 +63,7 @@ export default class PlanGateway {
 
     const request = {
       TableName: this.tableName,
-      IndexName: 'name_idx',
+      IndexName: 'NamesIndex',
       KeyConditionExpression: 'lastName = :l and firstName = :f',
       ExpressionAttributeValues: {
         ':l': lastName.toLowerCase(),

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,6 +5,8 @@ provider:
   runtime: nodejs12.x
   region: eu-west-2
   stage: ${opt:stage}
+  environment:
+    PLANS_TABLE: '${self:service}-${self:provider.stage}-plans'
 
 package:
   individually: true
@@ -34,6 +36,7 @@ functions:
 
     environment:
       ENV: ${self:provider.stage}
+      PLANS_TABLE_NAME: ${self:provider.environment.DROPBOXES_TABLE}
 
   hn-shared-plan-authorizer:
     name: hn-shared-plan-authorizer-${self:provider.stage}
@@ -49,6 +52,37 @@ functions:
 
 resources:
   Resources:
+    PlansTable:
+      Type: AWS::DynamoDB::Table
+      Properties:
+        TableName: ${self:provider.environment.DROPBOXES_TABLE}
+        BillingMode: PAY_PER_REQUEST
+        SSESpecification:
+          SSEEnabled: true
+        PointInTimeRecoverySpecification:
+          PointInTimeRecoveryEnabled: true
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+          - AttributeName: queryLastName
+            AttributeType: S
+          - AttributeName: queryFirstName
+            AttributeType: S
+        GlobalSecondaryIndexes:
+          - IndexName: NamesIndex
+            KeySchema:
+              - AttributeName: queryLastName
+                KeyType: HASH
+              - AttributeName: queryFirstName
+                KeyType: RANGE
+            Projection:
+              ProjectionType: INCLUDE
+              NonKeyAttributes:
+                - id
+                - systemIds
     GatewayResponseDefault4XX:
       Type: 'AWS::ApiGateway::GatewayResponse'
       Properties:

--- a/test/unit/gateways/plan-gateway.test.js
+++ b/test/unit/gateways/plan-gateway.test.js
@@ -142,7 +142,7 @@ describe('Plan Gateway', () => {
 
       const expectedRequest = {
         TableName: tableName,
-        IndexName: 'name_idx',
+        IndexName: 'NamesIndex',
         KeyConditionExpression: 'lastName = :l and firstName = :f',
         ExpressionAttributeValues: {
           ':f': customerData.firstName.toLowerCase(),


### PR DESCRIPTION
**What**
Adds the "plans" DynamoDB table to the serverless configuration.

**Why**
So that we automatically provision the table, and automate any updates to the table configuration in future changes.