### PR TITLE
Add Cypress accessibility testing

### DIFF
--- a/cypress/integration/acceptance/first.spec.js
+++ b/cypress/integration/acceptance/first.spec.js
@@ -2,13 +2,14 @@
 
 context('Home page', () => {
   beforeEach(() => {
-    cy.visit('http://localhost:3000/')
-  })
+    cy.visit('http://localhost:3000/');
+    cy.injectAxe();
+  });
 
   describe('Loads page', () => {
     it('has shared plan heading', () => {
-      cy.get('h1')
-        .should('have.text', 'Welcome to Shared Plan!')
-    })
-  })
-})
+      cy.get('h1').should('have.text', 'Welcome to Shared Plan!');
+      cy.checkA11y(null, null, cy.terminalLog);
+    });
+  });
+});

--- a/cypress/integration/acceptance/first.spec.js
+++ b/cypress/integration/acceptance/first.spec.js
@@ -1,5 +1,4 @@
 /// <reference types="cypress" />
-
 context('Home page', () => {
   beforeEach(() => {
     cy.visit('http://localhost:3000/');
@@ -9,7 +8,7 @@ context('Home page', () => {
   describe('Loads page', () => {
     it('has shared plan heading', () => {
       cy.get('h1').should('have.text', 'Welcome to Shared Plan!');
-      cy.checkA11y(null, null, cy.terminalLog);
+      cy.checkA11y('#content > h1', null, cy.terminalLog);
     });
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,15 +15,10 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-// module.exports = (on, config) => {
-//   // `on` is used to hook into various events Cypress emits
-//   // `config` is the resolved Cypress config
-//   config.ignoreTestFiles = '**/examples/*.spec.js';
-//   return config;
-// };
-
 //axe console printing
 module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
   on('task', {
     log(message) {
       console.log(message);

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -15,9 +15,27 @@
 /**
  * @type {Cypress.PluginConfig}
  */
+// module.exports = (on, config) => {
+//   // `on` is used to hook into various events Cypress emits
+//   // `config` is the resolved Cypress config
+//   config.ignoreTestFiles = '**/examples/*.spec.js';
+//   return config;
+// };
+
+//axe console printing
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
-  config.ignoreTestFiles = "**/examples/*.spec.js";
+  on('task', {
+    log(message) {
+      console.log(message);
+
+      return null;
+    },
+    table(message) {
+      console.table(message);
+
+      return null;
+    }
+  });
+  config.ignoreTestFiles = '**/examples/*.spec.js';
   return config;
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,25 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+function terminalLog(violations) {
+  cy.task(
+    'log',
+    `${violations.length} accessibility violation${
+      violations.length === 1 ? '' : 's'
+    } ${violations.length === 1 ? 'was' : 'were'} detected`
+  );
+  // pluck specific keys to keep the table readable
+  const violationData = violations.map(
+    ({ id, impact, description, nodes }) => ({
+      id,
+      impact,
+      description,
+      nodes: nodes.length
+    })
+  );
+
+  cy.task('table', violationData);
+}
+
+Cypress.Commands.add('terminalLog', terminalLog);

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -14,7 +14,7 @@
 // ***********************************************************
 
 // Import commands.js using ES2015 syntax:
-import './commands'
-
+import './commands';
+require('cypress-axe');
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/lib/use-cases/create-plan.js
+++ b/lib/use-cases/create-plan.js
@@ -1,4 +1,4 @@
-export default class GetPlan {
+export default class CreatePlan {
   constructor({ planGateway }) {
     this.planGateway = planGateway;
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "cookie-parser": "^1.4.5",
+    "cypress-axe": "^0.8.1",
     "jsonwebtoken": "^8.5.1",
     "nanoid": "^3.1.5",
     "next": "^9.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3928,6 +3928,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+cypress-axe@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.npm.taobao.org/cypress-axe/download/cypress-axe-0.8.1.tgz#ddb37dca6570c0642dda2388daf678e83b3e8d3f"
+  integrity sha1-3bN9ymVwwGQt2iOI2vZ46Ds+jT8=
+
 cypress@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-4.5.0.tgz#01940d085f6429cec3c87d290daa47bb976a7c7b"


### PR DESCRIPTION
WHAT: This PR adds Axe integration with Cypress in order to test for accessibility issues in the UI.

WHY: To easily identify what needs to be fixed so the page is accessible.

3rd party package added: cypress-axe (https://www.npmjs.com/package/cypress-axe)

Changes not related to this PR: Corrected the name of the exported function in create-plan use case from GetPlan to CreatePlan to reflect its functionality.

This is how it looks in the console when there is an accessibility issue:
<img width="692" alt="image" src="https://user-images.githubusercontent.com/54269120/82323097-7812cf00-99cf-11ea-9e87-40230b9aaace.png">
