### PR TITLE
Adds list of actions to plan summary

### DIFF
--- a/components/ActionsList/DueDate/index.js
+++ b/components/ActionsList/DueDate/index.js
@@ -1,0 +1,11 @@
+const format = new Intl.DateTimeFormat('en-GB', {
+  day: 'numeric',
+  month: 'long',
+  year: 'numeric'
+});
+
+const DueDate = ({ dateTime }) => (
+  <time dateTime={dateTime}>{format.format(new Date(dateTime))}</time>
+);
+
+export default DueDate;

--- a/components/ActionsList/index.js
+++ b/components/ActionsList/index.js
@@ -1,4 +1,5 @@
 import DueDate from './DueDate';
+import ExpandingText from 'components/ExpandingText';
 import Heading from 'components/Heading';
 import Table, {
   TableHead,
@@ -9,7 +10,7 @@ import Table, {
 } from 'components/Table';
 
 const ActionsList = ({ actions }) => (
-  <Table>
+  <Table className="lbh-actions-list__table">
     <TableHead>
       <TableRow className="lbh-actions-list__header">
         <TableHeader scope="col">Description</TableHeader>
@@ -21,10 +22,16 @@ const ActionsList = ({ actions }) => (
     <TableBody>
       {actions.map(action => (
         <TableRow key={action.title}>
-          <TableData>
+          <TableData className="lbh-actions-list__description">
             <Heading as="h2" size="m">
               {action.title}
             </Heading>
+            <ExpandingText
+              expandButtonText="Show details"
+              contractButtonText="Hide details"
+            >
+              {action.description}
+            </ExpandingText>
           </TableData>
           <TableData className="lbh-actions-list__due-date">
             <DueDate dateTime={action.dueDate} />

--- a/components/ActionsList/index.js
+++ b/components/ActionsList/index.js
@@ -32,6 +32,9 @@ const ActionsList = ({ actions }) => (
             >
               {action.description}
             </ExpandingText>
+            <div className="lbh-actions-list__descriptions-mobile">
+              Due <DueDate dateTime={action.dueDate} />
+            </div>
           </TableData>
           <TableData className="lbh-actions-list__due-date">
             <DueDate dateTime={action.dueDate} />

--- a/components/ActionsList/index.js
+++ b/components/ActionsList/index.js
@@ -1,0 +1,38 @@
+import DueDate from './DueDate';
+import Heading from 'components/Heading';
+import Table, {
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableData
+} from 'components/Table';
+
+const ActionsList = ({ actions }) => (
+  <Table>
+    <TableHead>
+      <TableRow className="lbh-actions-list__header">
+        <TableHeader scope="col">Description</TableHeader>
+        <TableHeader scope="col" className="lbh-actions-list__due-date">
+          Due date
+        </TableHeader>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {actions.map(action => (
+        <TableRow key={action.title}>
+          <TableData>
+            <Heading as="h2" size="m">
+              {action.title}
+            </Heading>
+          </TableData>
+          <TableData className="lbh-actions-list__due-date">
+            <DueDate dateTime={action.dueDate} />
+          </TableData>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+);
+
+export default ActionsList;

--- a/components/ExpandingText/index.js
+++ b/components/ExpandingText/index.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+const ExpandingText = ({ expandButtonText, contractButtonText, children }) => {
+  const [isExpanded, setExpanded] = useState(false);
+
+  if (isExpanded) {
+    return (
+      <>
+        {children}
+        <button
+          className="lbh-link-button lbh-link-button__up"
+          data-testid="text-contract-button"
+          onClick={() => setExpanded(false)}
+        >
+          {contractButtonText}
+        </button>
+      </>
+    );
+  }
+
+  return (
+    <button
+      className="lbh-link-button lbh-link-button__down"
+      data-testid="text-expand-button"
+      onClick={() => setExpanded(true)}
+    >
+      {expandButtonText}
+    </button>
+  );
+};
+
+export default ExpandingText;

--- a/components/Heading/index.js
+++ b/components/Heading/index.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const sizes = {
+  xl: 'govuk-heading-xl',
+  l: 'govuk-heading-l',
+  m: 'govuk-heading-m',
+  s: 'govuk-heading-s'
+};
+
+const defaults = {
+  h1: 'xl',
+  h2: 'l',
+  h3: 'm',
+  h4: 's'
+};
+
+const Heading = ({ as, size, children }) => {
+  return React.createElement(
+    as,
+    {
+      className: sizes[size || defaults[as]]
+    },
+    children
+  );
+};
+
+export default Heading;

--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -1,0 +1,36 @@
+const classNames = (className, extraClassNames = '') => {
+  return [className, extraClassNames].join(' ');
+};
+
+const TableTitle = ({ title }) => (
+  <caption className="govuk-table__caption">{title}</caption>
+);
+
+const TableHead = ({ children }) => (
+  <thead className="govuk-table__head">{children}</thead>
+);
+
+const TableBody = ({ children }) => (
+  <tbody className="govuk-table__body">{children}</tbody>
+);
+
+const TableRow = ({ children, className }) => (
+  <tr className={classNames('govuk-table__row', className)}>{children}</tr>
+);
+
+const TableHeader = ({ children, className, scope }) => (
+  <th scope={scope} className={classNames('govuk-table__header', className)}>
+    {children}
+  </th>
+);
+
+const TableData = ({ children, className }) => (
+  <td className={classNames('govuk-table__cell', className)}>{children}</td>
+);
+
+const Table = ({ children }) => (
+  <table className="govuk-table">{children}</table>
+);
+
+export default Table;
+export { TableTitle, TableHead, TableBody, TableRow, TableHeader, TableData };

--- a/components/Table/index.js
+++ b/components/Table/index.js
@@ -28,8 +28,8 @@ const TableData = ({ children, className }) => (
   <td className={classNames('govuk-table__cell', className)}>{children}</td>
 );
 
-const Table = ({ children }) => (
-  <table className="govuk-table">{children}</table>
+const Table = ({ children, className }) => (
+  <table className={classNames('govuk-table', className)}>{children}</table>
 );
 
 export default Table;

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-jest": "^23.9.0",
     "eslint-plugin-prettier": "^3.1.1",
     "govuk-frontend": "^3.6.0",
+    "intl": "^1.2.5",
     "jest": "^25.5.4",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^1.18.2",

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -26,6 +26,14 @@ html.lbh-template > body.lbh-template__body * {
   }
 }
 
+.lbh-actions-list__table {
+  tr {
+    td, th {
+      padding: 1em 0;
+    }
+  }
+}
+
 .lbh-actions-list__header {
   th {
     font-weight: normal;
@@ -33,6 +41,49 @@ html.lbh-template > body.lbh-template__body * {
   }
 }
 
+.lbh-actions-list__description {
+  h2 {
+    margin-bottom: 0.25em;
+  }
+}
+
 .lbh-actions-list__due-date {
   width: 12rem;
+}
+
+.lbh-link-button {
+  display: block;
+  font-family: inherit;
+  font-size: 1em;
+  color: #00513f;
+  background: none;
+  border: 0 none;
+  padding: 0;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.lbh-link-button:hover, .lbh-link-button:focus {
+  text-decoration: underline;
+}
+
+.lbh-link-button::after {
+  display: inline-block;
+  margin-left: 0.5em;
+}
+
+.lbh-link-button:hover::after {
+  text-decoration: none;
+}
+
+.lbh-link-button__down::after {
+  content: '▾';
+}
+
+.lbh-link-button__up {
+  margin-top: 0.5em;
+}
+
+.lbh-link-button__up::after {
+  content: '▴';
 }

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -1,6 +1,8 @@
 @import 'node_modules/govuk-frontend/govuk/all';
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;700&display=swap');
 
+$screen-sm-min: 576px;
+
 html.lbh-template > body.lbh-template__body * {
   font-family: 'Montserrat', sans-serif;
 }
@@ -45,10 +47,22 @@ html.lbh-template > body.lbh-template__body * {
   h2 {
     margin-bottom: 0.25em;
   }
+
+  .lbh-actions-list__descriptions-mobile {
+    margin-top: 1em;
+    
+    @media (min-width: #{$screen-sm-min}) {
+      display: none;
+    }
+  }
 }
 
 .lbh-actions-list__due-date {
   width: 12rem;
+  
+  @media (max-width: #{$screen-sm-min}) {
+    display: none;
+  }
 }
 
 .lbh-link-button {

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -25,3 +25,14 @@ html.lbh-template > body.lbh-template__body * {
     padding-top: 0.25rem;        
   }
 }
+
+.lbh-actions-list__header {
+  th {
+    font-weight: normal;
+    font-size: 1rem;
+  }
+}
+
+.lbh-actions-list__due-date {
+  width: 12rem;
+}

--- a/setupTests.js
+++ b/setupTests.js
@@ -1,3 +1,5 @@
+import IntlPolyfill from 'intl';
+import 'intl/locale-data/jsonp/en-GB';
 import '@testing-library/jest-dom/extend-expect';
 
 global.console = {
@@ -7,3 +9,10 @@ global.console = {
   info: console.info,
   debug: console.debug
 };
+
+if (global.Intl) {
+  Intl.NumberFormat = IntlPolyfill.NumberFormat;
+  Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+} else {
+  global.Intl = IntlPolyfill;
+}

--- a/test/unit/components/ActionsList/DueDate/index.test.js
+++ b/test/unit/components/ActionsList/DueDate/index.test.js
@@ -1,0 +1,12 @@
+import DueDate from 'components/ActionsList/DueDate';
+import { render } from '@testing-library/react';
+
+describe('<DueDate />', () => {
+  it('displays an ISO-8601 formatted date human-readably', () => {
+    const { getByText } = render(
+      <DueDate dateTime={'2020-05-26T09:00:00+0000'} />
+    );
+
+    expect(getByText('26 May 2020')).toBeInTheDocument();
+  });
+});

--- a/test/unit/components/ActionsList/index.test.js
+++ b/test/unit/components/ActionsList/index.test.js
@@ -20,7 +20,7 @@ describe('<ActionsList />', () => {
   });
 
   it('displays the due date of the action', () => {
-    const { getByText } = render(component);
-    expect(getByText('26 May 2020')).toBeInTheDocument();
+    const { getAllByText } = render(component);
+    expect(getAllByText('26 May 2020')[0]).toBeInTheDocument();
   });
 });

--- a/test/unit/components/ActionsList/index.test.js
+++ b/test/unit/components/ActionsList/index.test.js
@@ -1,0 +1,26 @@
+import ActionsList from 'components/ActionsList';
+import { render } from '@testing-library/react';
+
+describe('<ActionsList />', () => {
+  const component = (
+    <ActionsList
+      actions={[
+        {
+          title: 'Run a test',
+          description: 'This will check if it works',
+          dueDate: '2020-05-26T09:00:00+0000'
+        }
+      ]}
+    />
+  );
+
+  it('displays the title of the action', () => {
+    const { getByText } = render(component);
+    expect(getByText('Run a test')).toBeInTheDocument();
+  });
+
+  it('displays the due date of the action', () => {
+    const { getByText } = render(component);
+    expect(getByText('26 May 2020')).toBeInTheDocument();
+  });
+});

--- a/test/unit/components/ExpandingText/index.test.js
+++ b/test/unit/components/ExpandingText/index.test.js
@@ -1,0 +1,46 @@
+import ExpandingText from 'components/ExpandingText';
+import { render } from '@testing-library/react';
+
+describe('<ExpandingText />', () => {
+  const expectedContent = 'Hello world';
+  const component = (
+    <ExpandingText expandButtonText="More" contractButtonText="Less">
+      {expectedContent}
+    </ExpandingText>
+  );
+
+  describe('when not expanded', () => {
+    it('shows the expand button', () => {
+      const { getByText } = render(component);
+      expect(getByText('More')).toBeInTheDocument();
+    });
+
+    it('does not show the content', () => {
+      const { queryByText } = render(component);
+      expect(queryByText(expectedContent)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('clicking expand', () => {
+    const buttons = {
+      expand: 'text-expand-button',
+      contract: 'text-contract-button'
+    }
+
+    it('shows the content', () => {
+      const { getByText, getByTestId } = render(component);
+      getByTestId(buttons.expand).click();
+      expect(getByText(expectedContent)).toBeInTheDocument();
+    });
+
+    it('hides the content again after contracting', () => {
+      const { queryByText, getByTestId } = render(component);
+
+      getByTestId(buttons.expand).click();
+      expect(queryByText(expectedContent)).toBeInTheDocument();
+
+      getByTestId(buttons.contract).click();
+      expect(queryByText(expectedContent)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6372,6 +6372,11 @@ inquirer@^7.0.0, inquirer@^7.1.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+  integrity sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"


### PR DESCRIPTION
**What**  
Adds a table of actions to the plan summary page. This does not include the "completed" checkbox from the design at the moment, as that feature is not yet built.

Desktop
![image](https://user-images.githubusercontent.com/5405916/82896509-fcc09880-9f4d-11ea-9e28-d0469d8da30c.png)

Mobile
<img src="https://user-images.githubusercontent.com/5405916/82906740-92175900-9f5d-11ea-9398-97c28f2f8af8.png" width="50%" />

**Why**  
So that people viewing the plan can see the actions that have been agreed.

**Anything else?**  
 - Added a polyfill for `Intl` when running in Jest, as by default it doesn't have data for "en-GB" and so when testing things like date formatting we aren't able to reproduce browser behaviour.
