### PR TITLE
Add tests for Add action rendering in summary page and add a divider

### DIFF
--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -74,12 +74,14 @@ const AddAction = ({ id, updatePlan }) => {
   };
 
   return (
-    <div className="govuk-grid-row">
+    <div className="govuk-grid-row row-add-new-action">
       <div className="govuk-grid-column-one-quarter">
-        <h2 className="govuk-heading-m">Our Actions</h2>
+        <h2 className="govuk-heading-m heading-add-new-action">Our Actions</h2>
       </div>
       <div className="govuk-grid-column-three-quarters">
-        <h3 className="govuk-heading-m">Add new action</h3>
+        <h3 className="govuk-heading-m heading-add-new-action">
+          Add new action
+        </h3>
 
         <TextInput
           name="summary-text"

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -3,6 +3,7 @@ import AddGoal from 'components/Feature/AddGoal';
 import AddAction from 'components/Feature/AddAction';
 import GoalSummary from 'components/Feature/GoalSummary';
 import LegalText from 'components/Feature/LegalText';
+import ActionsList from 'components/ActionsList';
 
 const PlanSummary = ({ plan }) => {
   const [_plan, setPlan] = useState(plan);

--- a/pages/stylesheets/all.scss
+++ b/pages/stylesheets/all.scss
@@ -102,3 +102,11 @@ html.lbh-template > body.lbh-template__body * {
 .lbh-link-button__up::after {
   content: '▴';
 }
+.row-add-new-action {
+  border-top: 1px solid #000000;
+  margin-top: 40px;
+}
+
+.heading-add-new-action {
+  margin-top: 40px;
+}

--- a/test/unit/pages/plans/[id].test.js
+++ b/test/unit/pages/plans/[id].test.js
@@ -106,4 +106,28 @@ describe('PlanSummary', () => {
       expect(container.querySelector('.legal-text')).not.toBeInTheDocument();
     });
   });
+
+  describe('adding an action', () => {
+    xit('does not render an action if goal does not exist', () => {
+      const plan = {
+        id: '1',
+        firstName: 'Mr',
+        lastName: 'Don'
+      };
+      const { getByText } = render(<PlanSummary plan={plan} />);
+      expect(getByText('Our Actions')).not.toBeInTheDocument();
+    });
+
+    it('renders the add action form if goal exists', () => {
+      const plan = {
+        id: '1',
+        firstName: 'Mr',
+        lastName: 'Don',
+        goal: { text: 'text' }
+      };
+
+      const { getByText } = render(<PlanSummary plan={plan} />);
+      expect(getByText('Our Actions')).toBeInTheDocument();
+    });
+  });
 });

--- a/test/unit/pages/plans/[id].test.js
+++ b/test/unit/pages/plans/[id].test.js
@@ -108,14 +108,15 @@ describe('PlanSummary', () => {
   });
 
   describe('adding an action', () => {
-    xit('does not render an action if goal does not exist', () => {
+    it('does not render an action if goal does not exist', () => {
       const plan = {
         id: '1',
         firstName: 'Mr',
         lastName: 'Don'
       };
-      const { getByText } = render(<PlanSummary plan={plan} />);
-      expect(getByText('Our Actions')).not.toBeInTheDocument();
+      const { queryByText } = render(<PlanSummary plan={plan} />);
+
+      expect(queryByText('Our Actions')).toBeNull();
     });
 
     it('renders the add action form if goal exists', () => {


### PR DESCRIPTION
**What**  
Tests that add actions is rendered when Goal exists:
<img width="779" alt="image" src="https://user-images.githubusercontent.com/54268893/83253435-df393c00-a1a4-11ea-89bc-567a8ee0a2d5.png">


Tests that add actions is not rendered when Goal does not exist:
<img width="782" alt="image" src="https://user-images.githubusercontent.com/54268893/83253537-098af980-a1a5-11ea-98f7-11fc4cb97072.png">


and adds a divider between goal and actions.

**Why**  
To test the flow of the page use.

**Anything else?**  
Did not add/test Actions List on the summary page
