### PR TITLE
Abstracts away fetch calls and API logic from components

### DIFF
--- a/api/HttpStatusError.js
+++ b/api/HttpStatusError.js
@@ -1,0 +1,8 @@
+class HttpStatusError extends Error {
+  constructor(statusCode) {
+    super('Request was not successful');
+    this.statusCode = statusCode;
+  }
+}
+
+export { HttpStatusError };

--- a/api/api.js
+++ b/api/api.js
@@ -1,0 +1,38 @@
+import { HttpStatusError } from './HttpStatusError';
+
+async function request(path, options) {
+  const url = `${process.env.NEXT_PUBLIC_API_URL}${path}`;
+  const response = await fetch(url, {
+    ...options,
+    credentials: 'same-origin',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json'
+    },
+    body: options?.body ? JSON.stringify(options.body) : null
+  });
+
+  if (response.ok) {
+    return response.json();
+  } else {
+    throw new HttpStatusError(response.status);
+  }
+}
+
+export function requestPlan(planId) {
+  return request(`/plans/${planId}`);
+}
+
+export function requestAddGoal(planId, goal) {
+  return request(`/plans/${planId}/goals`, {
+    method: 'POST',
+    body: goal
+  });
+}
+
+export function requestAddAction(planId, action) {
+  return request(`/plans/${planId}/actions`, {
+    method: 'POST',
+    body: action
+  });
+}

--- a/api/api.js
+++ b/api/api.js
@@ -1,12 +1,13 @@
 import { HttpStatusError } from './HttpStatusError';
 
-async function request(path, options) {
+async function request(path, { token, ...options }) {
   const url = `${process.env.NEXT_PUBLIC_API_URL}${path}`;
   const response = await fetch(url, {
     ...options,
     credentials: 'same-origin',
     headers: {
       accept: 'application/json',
+      authorization: token ? `Bearer ${token}` : undefined,
       'content-type': 'application/json'
     },
     body: options?.body ? JSON.stringify(options.body) : null
@@ -19,20 +20,22 @@ async function request(path, options) {
   }
 }
 
-export function requestPlan(planId) {
-  return request(`/plans/${planId}`);
+export function requestPlan(planId, options) {
+  return request(`/plans/${planId}`, options);
 }
 
-export function requestAddGoal(planId, goal) {
+export function requestAddGoal(planId, goal, options) {
   return request(`/plans/${planId}/goals`, {
     method: 'POST',
-    body: goal
+    body: goal,
+    ...options
   });
 }
 
-export function requestAddAction(planId, action) {
+export function requestAddAction(planId, action, options) {
   return request(`/plans/${planId}/actions`, {
     method: 'POST',
-    body: action
+    body: action,
+    ...options
   });
 }

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,3 @@
+export * from './usePlan';
+export * from './api';
+export { HttpStatusError } from './HttpStatusError';

--- a/api/usePlan.js
+++ b/api/usePlan.js
@@ -1,22 +1,26 @@
 import useSWR from 'swr';
 import { requestPlan, requestAddGoal, requestAddAction } from './api';
 
-export function usePlan(planId, { initialPlan, ...options } = {}) {
-  const { data, error, mutate } = useSWR(planId, requestPlan, {
-    initialData: initialPlan,
-    ...options
-  });
+export function usePlan(planId, { initialPlan, token, ...options } = {}) {
+  const { data, error, mutate } = useSWR(
+    planId,
+    id => requestPlan(id, { token }),
+    {
+      initialData: initialPlan,
+      ...options
+    }
+  );
 
   return {
     plan: data,
     error,
     loading: data === null,
     addGoal: async goal => {
-      await requestAddGoal(planId, goal);
+      await requestAddGoal(planId, goal, { token });
       mutate({ ...data, goal });
     },
     addAction: async action => {
-      await requestAddAction(planId, action);
+      await requestAddAction(planId, action, { token });
       mutate({
         ...data,
         goal: {

--- a/api/usePlan.js
+++ b/api/usePlan.js
@@ -1,0 +1,36 @@
+import useSWR from 'swr';
+import { requestPlan, requestAddGoal, requestAddAction } from './api';
+
+export function usePlan(planId, { initialPlan, ...options } = {}) {
+  const { data, error, mutate } = useSWR(planId, requestPlan, {
+    initialData: initialPlan,
+    ...options
+  });
+
+  return {
+    plan: data,
+    error,
+    loading: data === null,
+    addGoal: async goal => {
+      await requestAddGoal(planId, goal);
+      mutate({ ...data, goal });
+    },
+    addAction: async action => {
+      await requestAddAction(planId, action);
+      mutate({
+        ...data,
+        goal: {
+          ...data.goal,
+          actions: data.goal.actions.concat({
+            ...action,
+            dueDate: new Date(
+              action.dueDate.year,
+              action.dueDate.month - 1,
+              action.dueDate.day
+            ).toISOString()
+          })
+        }
+      });
+    }
+  };
+}

--- a/api/usePlan.test.js
+++ b/api/usePlan.test.js
@@ -30,7 +30,6 @@ describe('usePlan', () => {
   });
 
   it('fetches a plan from the API', async () => {
-
     const Component = () => {
       const { plan } = usePlan(expectedPlan.id);
       return <p>{plan?.id}</p>;

--- a/api/usePlan.test.js
+++ b/api/usePlan.test.js
@@ -1,0 +1,98 @@
+import { useEffect } from 'react';
+import { usePlan } from './usePlan';
+import { enableFetchMocks } from 'jest-fetch-mock';
+import { render, waitFor } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+
+describe('usePlan', () => {
+  const expectedPlan = {
+    id: 'IRFaVaY2b',
+    firstName: 'Expected',
+    lastName: 'Plan',
+    goal: {
+      title: 'Have a goal',
+      actions: [
+        {
+          title: 'Have an action',
+          description: 'Once you believe, anything is possible.'
+        }
+      ]
+    }
+  };
+
+  beforeAll(() => {
+    enableFetchMocks();
+  });
+
+  beforeEach(() => {
+    fetch.mockReset();
+    fetch.mockResponse(JSON.stringify(expectedPlan));
+  });
+
+  it('fetches a plan from the API', async () => {
+
+    const Component = () => {
+      const { plan } = usePlan(expectedPlan.id);
+      return <p>{plan?.id}</p>;
+    };
+
+    const { getByText } = render(<Component />);
+    await waitFor(() => expect(getByText(expectedPlan.id)).toBeInTheDocument());
+  });
+
+  it('adds a goal via the API', () => {
+    const expectedGoal = {
+      text: 'Achieve a goal',
+      targetReviewDate: { day: 1, month: 2, year: 2003 },
+      useAsPhp: false
+    };
+
+    const Component = () => {
+      const { addGoal } = usePlan(expectedPlan.id);
+
+      useEffect(() => {
+        const add = async () => addGoal(expectedGoal);
+        add();
+      }, []);
+
+      return null;
+    };
+
+    act(() => render(<Component />));
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/plans/${expectedPlan.id}/goal`),
+      expect.objectContaining({
+        body: JSON.stringify(expectedGoal)
+      })
+    );
+  });
+
+  it('adds an action via the API', () => {
+    const expectedAction = {
+      summary: 'Do the action',
+      description: 'It will be super exciting',
+      dueDate: { day: 1, month: 2, year: 2003 }
+    };
+
+    const Component = () => {
+      const { addAction } = usePlan(expectedPlan.id);
+
+      useEffect(() => {
+        const add = async () => addAction(expectedAction);
+        add();
+      }, []);
+
+      return null;
+    };
+
+    act(() => render(<Component />));
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/plans/${expectedPlan.id}/actions`),
+      expect.objectContaining({
+        body: JSON.stringify(expectedAction)
+      })
+    );
+  });
+});

--- a/components/ActionsList/index.js
+++ b/components/ActionsList/index.js
@@ -21,10 +21,10 @@ const ActionsList = ({ actions }) => (
     </TableHead>
     <TableBody>
       {actions.map(action => (
-        <TableRow key={action.title}>
+        <TableRow key={action.summary}>
           <TableData className="lbh-actions-list__description">
             <Heading as="h2" size="m">
-              {action.title}
+              {action.summary}
             </Heading>
             <ExpandingText
               expandButtonText="Show details"

--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { DateInput, TextInput, Button, TextArea } from 'components/Form';
 import moment from 'moment';
 
-const AddAction = ({ hackneyToken, id, updatePlan }) => {
+const AddAction = ({ id, onActionAdded }) => {
   const [summary, setActionSummary] = useState('');
   const [dueDate, setDueDate] = useState({});
   const [description, setActionDescription] = useState('');
@@ -53,23 +53,7 @@ const AddAction = ({ hackneyToken, id, updatePlan }) => {
       return;
     }
 
-    const action = {
-      summary,
-      description,
-      dueDate
-    };
-
-    const response = await fetch(`/api/plans/${id}/actions`, {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${hackneyToken}`
-      },
-      body: JSON.stringify(action)
-    });
-    const plan = await response.json();
-    if (plan) await updatePlan(plan);
+    onActionAdded({ summary, description, dueDate });
   };
 
   return (

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -3,18 +3,14 @@ import moment from 'moment';
 import { Button, Checkbox, DateInput, TextInput } from 'components/Form';
 import { convertIsoDateToObject } from 'lib/utils/date';
 
-const AddGoal = ({ hackneyToken, plan, updatePlan }) => {
-  const [text, setGoalText] = useState(
-    plan.goal && plan.goal.text ? plan.goal.text : ''
-  );
+const AddGoal = ({ plan, onGoalAdded }) => {
+  const [text, setGoalText] = useState(plan?.goal?.text || '');
   const [targetReviewDate, setTargetReviewDate] = useState(
     plan.goal && plan.goal.targetReviewDate
       ? convertIsoDateToObject(plan.goal.targetReviewDate)
       : {}
   );
-  const [useAsPhp, setUseAsPhp] = useState(
-    plan.goal && plan.goal.useAsPhp ? true : false
-  );
+  const [useAsPhp, setUseAsPhp] = useState(plan?.goal?.useAsPhp || false);
   const [validate, setValidate] = useState(false);
 
   const handleGoalTextChange = e => {
@@ -50,23 +46,7 @@ const AddGoal = ({ hackneyToken, plan, updatePlan }) => {
       return;
     }
 
-    const response = await fetch(`/api/plans/${plan.id}/goals`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${hackneyToken}`
-      },
-      body: JSON.stringify({
-        goal: {
-          targetReviewDate,
-          text,
-          useAsPhp
-        }
-      })
-    });
-
-    const _plan = await response.json();
-    if (_plan) await updatePlan(_plan);
+    onGoalAdded({ targetReviewDate, text, useAsPhp });
   };
 
   return (

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -3,14 +3,14 @@ import moment from 'moment';
 import { Button, Checkbox, DateInput, TextInput } from 'components/Form';
 import { convertIsoDateToObject } from 'lib/utils/date';
 
-const AddGoal = ({ plan, onGoalAdded }) => {
-  const [text, setGoalText] = useState(plan?.goal?.text || '');
+const AddGoal = ({ goal, onGoalAdded }) => {
+  const [text, setGoalText] = useState(goal?.text || '');
   const [targetReviewDate, setTargetReviewDate] = useState(
-    plan.goal && plan.goal.targetReviewDate
-      ? convertIsoDateToObject(plan.goal.targetReviewDate)
+    goal && goal.targetReviewDate
+      ? convertIsoDateToObject(goal.targetReviewDate)
       : {}
   );
-  const [useAsPhp, setUseAsPhp] = useState(plan?.goal?.useAsPhp || false);
+  const [useAsPhp, setUseAsPhp] = useState(goal?.useAsPhp || false);
   const [validate, setValidate] = useState(false);
 
   const handleGoalTextChange = e => {

--- a/components/Feature/AddGoal/index.test.js
+++ b/components/Feature/AddGoal/index.test.js
@@ -1,13 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
-import { enableFetchMocks } from 'jest-fetch-mock';
 import AddGoal from './index';
 
 describe('AddGoal', () => {
-  beforeEach(() => {
-    enableFetchMocks();
-    fetch.resetMocks();
-  });
-
   it('renders the add goal form', () => {
     const { getByLabelText, getByText } = render(<AddGoal plan={{ id: 1 }} />);
     expect(getByLabelText('Goal')).toBeInTheDocument();
@@ -19,12 +13,9 @@ describe('AddGoal', () => {
   });
 
   it('saves the goal when add actions button is clicked', () => {
-    fetch.mockResponse(JSON.stringify({}));
-    const token = 'blah';
-    const updatePlan = jest.fn();
-    const plan = { id: 1 };
+    const onGoalAdded = jest.fn();
     const { getByLabelText, getByText } = render(
-      <AddGoal hackneyToken={token} plan={plan} updatePlan={updatePlan} />
+      <AddGoal onGoalAdded={onGoalAdded} />
     );
 
     fireEvent.change(getByLabelText('Goal'), {
@@ -48,30 +39,21 @@ describe('AddGoal', () => {
       })
     );
 
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(`/api/plans/${plan.id}/goals`),
-      expect.objectContaining({
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          goal: {
-            targetReviewDate: {
-              day: 12,
-              month: 10,
-              year: 2021
-            },
-            text: 'this is my goal',
-            useAsPhp: false
-          }
-        })
-      })
-    );
+    expect(onGoalAdded).toHaveBeenCalledWith({
+      targetReviewDate: {
+        day: 12,
+        month: 10,
+        year: 2021
+      },
+      text: 'this is my goal',
+      useAsPhp: false
+    });
   });
 
   it('does not save the goal if the form is not valid', () => {
-    const { getByText } = render(<AddGoal plan={{ id: 1 }} />);
+    const onGoalAdded = jest.fn();
+    const { getByText } = render(<AddGoal onGoalAdded={onGoalAdded} />);
+
     fireEvent(
       getByText('Add actions'),
       new MouseEvent('click', {
@@ -79,7 +61,8 @@ describe('AddGoal', () => {
         cancelable: true
       })
     );
-    expect(fetch).not.toHaveBeenCalled();
+
+    expect(onGoalAdded).not.toHaveBeenCalled();
   });
 
   it('sets the goal input value if goal already exists', () => {

--- a/components/Feature/AddGoal/index.test.js
+++ b/components/Feature/AddGoal/index.test.js
@@ -66,17 +66,13 @@ describe('AddGoal', () => {
   });
 
   it('sets the goal input value if goal already exists', () => {
-    const { getByLabelText } = render(
-      <AddGoal plan={{ id: 1, goal: { text: 'hello' } }} />
-    );
+    const { getByLabelText } = render(<AddGoal goal={{ text: 'hello' }} />);
     expect(getByLabelText('Goal').value).toEqual('hello');
   });
 
   it('sets the target review date input value if goal already exists', () => {
     const { getByLabelText } = render(
-      <AddGoal
-        plan={{ id: 1, goal: { targetReviewDate: '2022-10-20T00:00:00.000Z' } }}
-      />
+      <AddGoal goal={{ targetReviewDate: '2022-10-20T00:00:00.000Z' }} />
     );
     expect(getByLabelText('Day').value).toEqual('20');
     expect(getByLabelText('Month').value).toEqual('10');
@@ -84,9 +80,7 @@ describe('AddGoal', () => {
   });
 
   it('sets the use as php input value if goal already exists', () => {
-    const { getByLabelText } = render(
-      <AddGoal plan={{ id: 1, goal: { useAsPhp: true } }} />
-    );
+    const { getByLabelText } = render(<AddGoal goal={{ useAsPhp: true }} />);
     expect(getByLabelText('Use as a PHP').checked).toEqual(true);
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   setupFiles: ['dotenv/config'],
   testMatch: [
     '<rootDir>/test/**/*.[jt]s?(x)',
-    '<rootDir>/components/**/*.test.[jt]s?(x)'
+    '<rootDir>/**/*.test.[jt]s?(x)'
   ],
   testPathIgnorePatterns: ['/node_modules/', '/build/'],
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-dom": "16.13.1",
     "restana": "^4.3.4",
     "serve-static": "^1.14.1",
-    "serverless-http": "^2.4.1"
+    "serverless-http": "^2.4.1",
+    "swr": "^0.2.2"
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.6",

--- a/pages/api/plans/[id]/goals.js
+++ b/pages/api/plans/[id]/goals.js
@@ -3,15 +3,12 @@ import { ArgumentError } from 'lib/domain';
 import { logger } from 'lib/infrastructure/logging';
 
 export const endpoint = ({ addGoal }) => async (req, res) => {
-  const planId = req.url.split('/')[3];
-
   try {
     const result = await addGoal.execute({
-      goal: req.body.goal,
-      planId
+      planId: req.query.id,
+      goal: req.body
     });
 
-    logger.info(`Success`, { result });
     res.status(200).json(result);
   } catch (err) {
     logger.error(err.message, { err });
@@ -19,8 +16,9 @@ export const endpoint = ({ addGoal }) => async (req, res) => {
       return res.status(400).json({ error: `could not add goal to plan` });
     }
 
+    console.log(req.body.planId);
     res.status(500).json({
-      error: `could not add goal to plan with id=${planId}`
+      error: `could not add goal to plan with id=${req.query.id}`
     });
   }
 };

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -1,15 +1,24 @@
 import { useState } from 'react';
+import { usePlan, requestPlan, HttpStatusError } from 'api';
 import AddGoal from 'components/Feature/AddGoal';
 import AddAction from 'components/Feature/AddAction';
+import ActionsList from 'components/ActionsList';
 import GoalSummary from 'components/Feature/GoalSummary';
 import LegalText from 'components/Feature/LegalText';
 import { Button } from 'components/Form';
 import { getToken } from 'lib/utils/token';
 
-const PlanSummary = ({ hackneyToken, plan }) => {
-  const [_plan, setPlan] = useState(plan);
-  const [editGoal, setEditGoal] = useState(!_plan.goal ? true : false);
-  const { id, firstName, lastName, goal } = _plan;
+const PlanSummary = ({ planId, initialPlan }) => {
+  const { plan, loading, addGoal, addAction } = usePlan(planId, {
+    initialPlan
+  });
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  const [editGoal, setEditGoal] = useState(!plan.goal ? true : false);
+  const { id, firstName, lastName, goal } = plan;
 
   const getPossessiveName = (firstName, lastName) => {
     let baseString = `${firstName} ${lastName}'`;
@@ -22,60 +31,40 @@ const PlanSummary = ({ hackneyToken, plan }) => {
     return baseString;
   };
 
-  const updatePlan = async newPlan => {
-    setPlan(newPlan);
-    setEditGoal(false);
-  };
-
   return (
     <>
       <h1>{getPossessiveName(firstName, lastName)} shared plan</h1>
       {editGoal && (
         <AddGoal
-          hackneyToken={hackneyToken}
-          plan={_plan}
-          updatePlan={updatePlan}
+          planId={id}
+          onGoalAdded={async goal => {
+            await addGoal(goal);
+            setEditGoal(false);
+          }}
         />
       )}
-      {!editGoal && <GoalSummary hackneyToken={hackneyToken} plan={_plan} />}
+      {!editGoal && <GoalSummary plan={plan} />}
       {!editGoal && (
         <Button text="Edit goal" onClick={() => setEditGoal(true)} />
       )}
-      {!editGoal && (
-        <AddAction
-          hackneyToken={hackneyToken}
-          id={id}
-          updatePlan={updatePlan}
-        />
-      )}
+      <ActionsList actions={plan.goal?.actions || []} />
+      {!editGoal && <AddAction id={id} onActionAdded={addAction} />}
       {!editGoal && goal && goal.useAsPhp && <LegalText />}
     </>
   );
 };
 
-PlanSummary.getInitialProps = async ({ query, req, res }) => {
-  const hackneyToken = getToken(req);
+PlanSummary.getInitialProps = async ({ query: { id }, res }) => {
+  try {
+    const plan = await requestPlan(id);
 
-  const response = await fetch(
-    `${process.env.SHARED_PLAN_API_URL}/plans/${query.id}`,
-    {
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${hackneyToken}`
-      }
-    }
-  );
-  if (response.status === 404) {
-    res.statusCode = 404;
-    return res.end('Not found');
+    return {
+      planId: id,
+      initialPlan: plan
+    };
+  } catch (err) {
+    res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();
   }
-
-  const plan = await response.json();
-
-  return {
-    hackneyToken,
-    plan
-  };
 };
 
 export default PlanSummary;

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -8,9 +8,10 @@ import LegalText from 'components/Feature/LegalText';
 import { Button } from 'components/Form';
 import { getToken } from 'lib/utils/token';
 
-const PlanSummary = ({ planId, initialPlan }) => {
+const PlanSummary = ({ planId, initialPlan, token }) => {
   const { plan, loading, addGoal, addAction } = usePlan(planId, {
-    initialPlan
+    initialPlan,
+    token
   });
 
   if (loading) {
@@ -54,13 +55,15 @@ const PlanSummary = ({ planId, initialPlan }) => {
   );
 };
 
-PlanSummary.getInitialProps = async ({ query: { id }, res }) => {
+PlanSummary.getInitialProps = async ({ query: { id }, req, res }) => {
   try {
-    const plan = await requestPlan(id);
+    const token = getToken(req);
+    const plan = await requestPlan(id, { token });
 
     return {
       planId: id,
-      initialPlan: plan
+      initialPlan: plan,
+      token
     };
   } catch (err) {
     res.writeHead(err instanceof HttpStatusError ? err.statusCode : 500).end();

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -36,7 +36,7 @@ const PlanSummary = ({ planId, initialPlan }) => {
       <h1>{getPossessiveName(firstName, lastName)} shared plan</h1>
       {editGoal && (
         <AddGoal
-          planId={id}
+          goal={goal}
           onGoalAdded={async goal => {
             await addGoal(goal);
             setEditGoal(false);

--- a/test/unit/components/ActionsList/index.test.js
+++ b/test/unit/components/ActionsList/index.test.js
@@ -6,7 +6,7 @@ describe('<ActionsList />', () => {
     <ActionsList
       actions={[
         {
-          title: 'Run a test',
+          summary: 'Run a test',
           description: 'This will check if it works',
           dueDate: '2020-05-26T09:00:00+0000'
         }

--- a/test/unit/pages/api/plans/[id]/goals.test.js
+++ b/test/unit/pages/api/plans/[id]/goals.test.js
@@ -21,10 +21,10 @@ describe('Add goal API', () => {
 
   const req = {
     method: 'POST',
-    url: `localdev/api/plans/${planId}/goals`,
-    body: {
-      goal
-    }
+    query: {
+      id: planId
+    },
+    body: goal
   };
 
   it('can add a goal to a plan', async () => {

--- a/test/unit/pages/plans/[id].test.js
+++ b/test/unit/pages/plans/[id].test.js
@@ -3,6 +3,18 @@ import { render } from '@testing-library/react';
 import PlanSummary from 'pages/plans/[id]';
 
 describe('PlanSummary', () => {
+  const expectedResponse = {
+    id: '1',
+    firstName: 'James',
+    lastName: 'Bond',
+    goal: { text: 'my goal' }
+  };
+
+  beforeEach(() => {
+    enableFetchMocks();
+    fetch.mockResponse(JSON.stringify(expectedResponse));
+  });
+
   it('renders correct title', () => {
     const plan = {
       id: '1',
@@ -10,7 +22,7 @@ describe('PlanSummary', () => {
       lastName: 'Test',
       goal: { text: 'my goal' }
     };
-    const { getByText } = render(<PlanSummary plan={plan} />);
+    const { getByText } = render(<PlanSummary initialPlan={plan} />);
     expect(getByText("Bob Test's shared plan")).toBeInTheDocument();
   });
 
@@ -21,7 +33,7 @@ describe('PlanSummary', () => {
       lastName: 'Tes',
       goal: { text: 'my goal' }
     };
-    const { getByText } = render(<PlanSummary plan={plan} />);
+    const { getByText } = render(<PlanSummary initialPlan={plan} />);
     expect(getByText("Bob Tes' shared plan")).toBeInTheDocument();
   });
 
@@ -32,7 +44,7 @@ describe('PlanSummary', () => {
       lastName: 'Musk',
       goal: { text: 'my goal' }
     };
-    const { getByText } = render(<PlanSummary plan={plan} />);
+    const { getByText } = render(<PlanSummary initialPlan={plan} />);
     expect(getByText("X Æ A-12 Musk's shared plan")).toBeInTheDocument();
   });
 
@@ -43,33 +55,14 @@ describe('PlanSummary', () => {
       lastName: '',
       goal: { text: 'my goal' }
     };
-    const { getByText } = render(<PlanSummary plan={plan} />);
+    const { getByText } = render(<PlanSummary initialPlan={plan} />);
     expect(getByText("Dan's shared plan")).toBeInTheDocument();
   });
 
   it('fetches plan from the correct url and constructs correct props', async () => {
-    enableFetchMocks();
-    const expectedResponse = {
-      id: '1',
-      firstName: 'James',
-      lastName: 'Bond',
-      goal: { text: 'my goal' }
-    };
-    fetch.mockResponse(JSON.stringify(expectedResponse));
-    const props = await PlanSummary.getInitialProps({
-      req: { headers: { cookie: 'hackneyToken=TOKEN' } },
-      query: { id: '1' }
-    });
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining('/plans/1'),
-      expect.objectContaining({
-        headers: {
-          Authorization: 'Bearer TOKEN',
-          'Content-Type': 'application/json'
-        }
-      })
-    );
-    expect(props.plan).toStrictEqual(expectedResponse);
+    const props = await PlanSummary.getInitialProps({ query: { id: '1' } });
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('/plans/1'), expect.any(Object));
+    expect(props.initialPlan).toStrictEqual(expectedResponse);
   });
 
   describe('adding a goal', () => {
@@ -81,13 +74,13 @@ describe('PlanSummary', () => {
         lastName: 'Musk',
         goal: { text: goalText }
       };
-      const { getByText } = render(<PlanSummary plan={plan} />);
+      const { getByText } = render(<PlanSummary initialPlan={plan} />);
       expect(getByText(goalText)).toBeInTheDocument();
     });
 
     it('renders the add goal form if goal is falsy', () => {
       const plan = { id: '1', firstName: 'John', lastName: 'Musk' };
-      const { getByLabelText } = render(<PlanSummary plan={plan} />);
+      const { getByLabelText } = render(<PlanSummary initialPlan={plan} />);
       expect(getByLabelText('Goal')).toBeInTheDocument();
     });
 
@@ -100,7 +93,7 @@ describe('PlanSummary', () => {
           useAsPhp: true
         }
       };
-      const { container } = render(<PlanSummary plan={plan} />);
+      const { container } = render(<PlanSummary initialPlan={plan} />);
       expect(container.querySelector('.legal-text')).toBeInTheDocument();
     });
 
@@ -113,7 +106,7 @@ describe('PlanSummary', () => {
           useAsPhp: false
         }
       };
-      const { container } = render(<PlanSummary plan={plan} />);
+      const { container } = render(<PlanSummary initialPlan={plan} />);
       expect(container.querySelector('.legal-text')).not.toBeInTheDocument();
     });
   });
@@ -125,7 +118,7 @@ describe('PlanSummary', () => {
         firstName: 'Mr',
         lastName: 'Don'
       };
-      const { queryByText } = render(<PlanSummary plan={plan} />);
+      const { queryByText } = render(<PlanSummary initialPlan={plan} />);
 
       expect(queryByText('Our Actions')).toBeNull();
     });
@@ -138,7 +131,7 @@ describe('PlanSummary', () => {
         goal: { text: 'text' }
       };
 
-      const { getByText } = render(<PlanSummary plan={plan} />);
+      const { getByText } = render(<PlanSummary initialPlan={plan} />);
       expect(getByText('Our Actions')).toBeInTheDocument();
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5265,6 +5265,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-deep-equal@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -11218,6 +11223,13 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+swr@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.2.2.tgz#6e1b3e5c0e545c4fdb36ae3aa38cd94d0f9a88b7"
+  integrity sha512-D/z+PTUchZhoUA0tNC8TNJivf7Hc61WPxbUdXPi+VxRloddWYNP1ZicaEgyAph42ZnKl1L7twcZr4q6d0UMXcg==
+  dependencies:
+    fast-deep-equal "2.0.1"
 
 symbol-observable@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
**What**  
Abstracts away the `fetch` and API logic from the components and introduces a `usePlan` hook that controls interactions with the API.

**Why**  
This provides a single re-usable interface for interacting with the API and allows components to be more easily tested as there is not a bunch of network logic living inside of them and they no longer have to deal with all of those concerns.

**Anything else?**  
 - Added [SWR](https://swr.now.sh/), a library for handling `fetch` calls that provides revalidation and optimistic updates.
 - Added `ActionsList` to the plan summary page, this is a single line change.
 - Refactored `/plans/{id}/goal` to take the plan id from the URL rather than the body, unwrapped `goal` from the body. Fixed up all the tests.
