### PR TITLE
Fixes "act" warning in hook tests

### DIFF
--- a/api/usePlan.test.js
+++ b/api/usePlan.test.js
@@ -1,8 +1,7 @@
-import { useEffect } from 'react';
 import { usePlan } from './usePlan';
 import { enableFetchMocks } from 'jest-fetch-mock';
-import { render, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from 'react-test-renderer';
 
 describe('usePlan', () => {
   const expectedPlan = {
@@ -30,34 +29,23 @@ describe('usePlan', () => {
   });
 
   it('fetches a plan from the API', async () => {
-    const Component = () => {
-      const { plan } = usePlan(expectedPlan.id);
-      return <p>{plan?.id}</p>;
-    };
+    const { result, waitForNextUpdate } = renderHook(() =>
+      usePlan(expectedPlan.id)
+    );
 
-    const { getByText } = render(<Component />);
-    await waitFor(() => expect(getByText(expectedPlan.id)).toBeInTheDocument());
+    await waitForNextUpdate();
+    expect(result.current.plan).toStrictEqual(expectedPlan);
   });
 
-  it('adds a goal via the API', () => {
+  it('adds a goal via the API', async () => {
     const expectedGoal = {
       text: 'Achieve a goal',
       targetReviewDate: { day: 1, month: 2, year: 2003 },
       useAsPhp: false
     };
 
-    const Component = () => {
-      const { addGoal } = usePlan(expectedPlan.id);
-
-      useEffect(() => {
-        const add = async () => addGoal(expectedGoal);
-        add();
-      }, []);
-
-      return null;
-    };
-
-    act(() => render(<Component />));
+    const { result } = renderHook(() => usePlan(expectedPlan.id));
+    await act(() => result.current.addGoal(expectedGoal));
 
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(`/plans/${expectedPlan.id}/goal`),
@@ -67,25 +55,15 @@ describe('usePlan', () => {
     );
   });
 
-  it('adds an action via the API', () => {
+  it('adds an action via the API', async () => {
     const expectedAction = {
       summary: 'Do the action',
       description: 'It will be super exciting',
       dueDate: { day: 1, month: 2, year: 2003 }
     };
 
-    const Component = () => {
-      const { addAction } = usePlan(expectedPlan.id);
-
-      useEffect(() => {
-        const add = async () => addAction(expectedAction);
-        add();
-      }, []);
-
-      return null;
-    };
-
-    act(() => render(<Component />));
+    const { result } = renderHook(() => usePlan(expectedPlan.id));
+    await act(() => result.current.addAction(expectedAction));
 
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(`/plans/${expectedPlan.id}/actions`),

--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,8 @@ module.exports = {
     '^.+\\.module\\.(css|sass|scss)$'
   ],
   moduleNameMapper: {
-    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy'
+    '^.+\\.module\\.(css|sass|scss)$': 'identity-obj-proxy',
+    '^react(.*)$': '<rootDir>/node_modules/react$1'
   },
   moduleDirectories: ['node_modules', '.']
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/runtime": "^7.9.6",
     "@testing-library/jest-dom": "^5.7.0",
     "@testing-library/react": "^10.0.4",
+    "@testing-library/react-hooks": "^3.2.1",
     "aws-sdk": "^2.669.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",
@@ -52,6 +53,7 @@
     "jest": "^25.5.4",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "^1.18.2",
+    "react-test-renderer": "16.13.1",
     "sass": "^1.26.5",
     "serverless": "^1.70.1",
     "start-server-and-test": "^1.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -930,6 +930,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.5.4":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.3.3", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -1557,6 +1564,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
+  integrity sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.0.0"
+
 "@testing-library/react@^10.0.4":
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.0.4.tgz#8e0e299cd91acc626d81ed8489fdc13df864c31d"
@@ -1764,6 +1779,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
+  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.35"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.35.tgz#a0830d172e8aadd9bd41709ba2281a3124bbd368"
@@ -1820,6 +1842,14 @@
   integrity sha512-LoZ3uonlnAbJUz4bg6UoeFl+frfndXngmkCItSjJ8DD5WlRfVqPC5/LgJASsY/dy7AHH2YJ7PcsdASOydcVeFA==
   dependencies:
     "@types/jest" "*"
+
+"@types/testing-library__react-hooks@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz#52f3a109bef06080e3b1e3ae7ea1c014ce859897"
+  integrity sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-test-renderer" "*"
 
 "@types/testing-library__react@^10.0.1":
   version "10.0.1"
@@ -9721,7 +9751,7 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1:
+react-is@16.13.1, react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9730,6 +9760,16 @@ react-refresh@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.2.tgz#24bb0858eac92b0d7b0dd561747f0c9fd6c60327"
   integrity sha512-n8GXxo3DwM2KtFEL69DAVhGc4A1THn2qjmfvSo3nze0NLCoPbywazeJPqdp0RdSGLmyhQzeyA+XPXOobbYlkzg==
+
+react-test-renderer@16.13.1:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
+  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
 
 react@16.13.1:
   version "16.13.1"


### PR DESCRIPTION
**What**  
Reworks the tests for the "usePlan" hook to fix the warning about component updates not happening inside of an `act(...)` wrapper. This also simplifies the tests by switching to `@testing-library/react-hooks` so we don't need our own component wrapper to test things.
```
Warning: An update to Component inside a test was not wrapped in act(...).
```

**Why**  
To fix the warning and ensure our tests are reliable around the async logic inside of the hook.

**Anything else?**  
 - Added `@testing-library/react-hooks`, for testing hooks.
 - Updated the Jest config to correctly resolve `react` at all times, `react-hooks` tries resolves `react` imports to `@testing-library/react` as it is the closest "react" it can find 🤦 
