### PR TITLE
Remove redundant workspace persistence from circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,17 +76,10 @@ jobs:
       - store_artifacts:
           path: ~/repo/cypress/videos
 
-      - persist_to_workspace:
-          root: ~/repo
-          paths: .
-
   build-deploy-staging:
     executor: aws-cli/default
 
     steps:
-      - attach_workspace:
-          at: ~/repo
-
       - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY
@@ -102,9 +95,6 @@ jobs:
     executor: aws-cli/default
 
     steps:
-      - attach_workspace:
-          at: ~/repo
-
       - aws-cli/setup:
           aws-access-key-id: AWS_ACCESS_KEY_ID
           aws-secret-access-key: AWS_SECRET_ACCESS_KEY

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,9 @@ jobs:
 
       - run:
           name: Build the application
-          command: yarn build
+          command: |
+            export NEXT_PUBLIC_API_URL=http://localhost:3000/api
+            yarn build
 
       - run:
           name: Run unit tests
@@ -64,7 +66,9 @@ jobs:
 
       - run:
           name: Run integration tests
-          command: CYPRESS_CACHE_FOLDER=~/repo/cypress_cache yarn run int-test
+          command: |
+            export NEXT_PUBLIC_API_URL=http://localhost:3000/api
+            CYPRESS_CACHE_FOLDER=~/repo/cypress_cache yarn run int-test
 
       - store_artifacts:
           path: ~/repo/cypress/screenshots
@@ -90,7 +94,9 @@ jobs:
 
       - run:
           name: deploy
-          command: cd ../repo && yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s staging
+          command: |
+            export NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL_STAGING}
+            cd ../repo && yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s staging
 
   build-deploy-production:
     executor: aws-cli/default
@@ -106,7 +112,9 @@ jobs:
 
       - run:
           name: deploy
-          command: cd ../repo && yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s production
+          command: |
+            export NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL_PRODUCTION}
+            cd ../repo && yarn build && yarn --production=true && sudo npm i -g serverless && sls deploy -s production
 
 workflows:
   version: 2


### PR DESCRIPTION
**What**  
Remove redundant workspace persistence from circleci

**Why**  
Because it's slow and we don't need it
