### PR TITLE
Add env var to public url

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -50,7 +50,7 @@ functions:
       SMS_API_URL: ${ssm:/shared-plan/SMS_API_URL}
       PLANS_TABLE_NAME: ${self:provider.environment.PLANS_TABLE}
       NEXT_PUBLIC_API_URL: https://${self:custom.aliases.${self:provider.stage}}/api
-      NEXT_PUBLIC_URL: ${self:provider.environment.NEXT_PUBLIC_URL}
+      NEXT_PUBLIC_URL: https://${self:custom.aliases.${self:provider.stage}}
 
   hn-shared-plan-authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}

--- a/serverless.yml
+++ b/serverless.yml
@@ -50,6 +50,7 @@ functions:
       SMS_API_URL: ${ssm:/shared-plan/SMS_API_URL}
       PLANS_TABLE_NAME: ${self:provider.environment.PLANS_TABLE}
       NEXT_PUBLIC_API_URL: https://${self:custom.aliases.${self:provider.stage}}/api
+      NEXT_PUBLIC_URL: ${self:provider.environment.NEXT_PUBLIC_URL}
 
   hn-shared-plan-authorizer:
     name: ${self:service}-authorizer-${self:provider.stage}


### PR DESCRIPTION
**What**  
Add public url env var to the serverless.

**Why**  
To point residents to the correct shared plan url
