### PR TITLE
Hotfix/share status and change date to empty 

### DIFF
--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -5,7 +5,7 @@ import css from './index.module.scss';
 
 const AddAction = ({ onActionAdded }) => {
   const [summary, setActionSummary] = useState('');
-  const [dueDate, setDueDate] = useState({});
+  const [dueDate, setDueDate] = useState({ day: '', month: '', year: '' });
   const [description, setActionDescription] = useState('');
   const [validate, setValidate] = useState(false);
 

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -8,7 +8,7 @@ const AddGoal = ({ goal, onGoalAdded }) => {
   const [targetReviewDate, setTargetReviewDate] = useState(
     goal && goal.targetReviewDate
       ? convertIsoDateToObject(goal.targetReviewDate)
-      : {}
+      : { day: '', month: '', year: '' }
   );
   const [useAsPhp, setUseAsPhp] = useState(goal?.useAsPhp || false);
   const [validate, setValidate] = useState(false);

--- a/components/Feature/SharePlan/ShareStatus/index.js
+++ b/components/Feature/SharePlan/ShareStatus/index.js
@@ -28,7 +28,7 @@ const formatDate = date => {
 const ShareStatus = ({ name, customerTokens }) => {
   let shareStatus = `Not yet shared with ${name}`;
 
-  if (customerTokens?.length > 1) {
+  if (customerTokens?.length > 0) {
     const dateTimes = customerTokens
       .map(token => new Date(token.createdDate))
       .sort((a, b) => {

--- a/pages/plans/[id]/share.js
+++ b/pages/plans/[id]/share.js
@@ -3,9 +3,9 @@ import PlanHeader from 'components/PlanHeader';
 import { usePlan, requestPlan, HttpStatusError } from 'api';
 import { getToken } from 'lib/utils/token';
 
-const Share = ({ plan, planId, token }) => {
-  const { error, loading, sharePlan } = usePlan(planId, {
-    plan,
+const Share = ({ initialPlan, planId, token }) => {
+  const { error, loading, sharePlan, plan } = usePlan(planId, {
+    initialPlan,
     token
   });
 
@@ -27,7 +27,7 @@ Share.getInitialProps = async ({ query: { id }, req, res }) => {
     const plan = await requestPlan(id, { token });
     return {
       planId: id,
-      plan,
+      initialPlan: plan,
       token
     };
   } catch (err) {

--- a/pages/plans/[id]/share.test.js
+++ b/pages/plans/[id]/share.test.js
@@ -11,7 +11,7 @@ describe('Share', () => {
       numbers: [],
       emails: []
     };
-    const { getByText } = render(<Share plan={plan} />);
+    const { getByText } = render(<Share initialPlan={plan} />);
     expect(getByText("Bob Test's shared plan")).toBeInTheDocument();
   });
 
@@ -33,7 +33,7 @@ describe('Share', () => {
       numbers: ['sample_nr'],
       emails: ['sample_email']
     };
-    const { getByText } = render(<Share plan={plan} />);
+    const { getByText } = render(<Share initialPlan={plan} />);
 
     expect(getByText('sample_nr')).toBeInTheDocument();
     expect(getByText('sample_email')).toBeInTheDocument();


### PR DESCRIPTION
**What**  
Enable share status time to update as soon as the plan is shared.
<img width="216" alt="image" src="https://user-images.githubusercontent.com/54268893/84051215-b3893380-a9a6-11ea-97e3-7966828c7135.png">

Change date to empty instead of undefined in add goal component.

Fix 1 to 0 to check for at least one customer token when creating a share status.

**Why**  
To fix _Warning: A component is changing an uncontrolled input of type text_ 
To dynamically update the time of share. 
