### PR TITLE
Adds support for toggling action completion status (customers)

### DIFF
--- a/cypress/integration/features/toggle-action.spec.js
+++ b/cypress/integration/features/toggle-action.spec.js
@@ -1,0 +1,41 @@
+context('with no completed actions', () => {
+  beforeEach(() => {
+    cy.task('createPlan', {
+      id: '1',
+      firstName: 'Bart',
+      lastName: 'Simpson',
+      queryFirstName: 'bart',
+      queryLastName: 'simpson',
+      goal: {
+        targetReviewDate: '2022-05-29T00:00:00.000Z',
+        text: 'This is a test goal',
+        useAsPhp: false,
+        actions: [
+          {
+            id: 'PPbqWA9',
+            summary: 'This is a test action',
+            description: 'We will complete this action in a test!',
+            dueDate: '2020-05-20',
+            isCompleted: false
+          }
+        ]
+      }
+    });
+
+    cy.setHackneyCookie(true);
+    cy.visit('http://localhost:3000/plans/1');
+  });
+
+  afterEach(() => {
+    cy.task('deletePlan', '1');
+  });
+
+  describe('toggling the action checkbox', () => {
+    it('can complete an action', () => {
+      cy.get('[data-testid=action-checkbox]').check();
+      cy.reload();
+
+      cy.get('[data-testid=action-checkbox]').should('have.attr', 'checked');
+    });
+  });
+});

--- a/pages/customer/plans/[id].js
+++ b/pages/customer/plans/[id].js
@@ -1,12 +1,12 @@
 import { usePlan, requestPlan, HttpStatusError } from 'api';
+import PlanHeader from 'components/PlanHeader';
 import ActionsList from 'components/Feature/ActionsList';
 import GoalSummary from 'components/Feature/GoalSummary';
 import LegalText from 'components/Feature/LegalText';
 import { createToken } from 'lib/utils/token';
-import { getPossessiveName } from 'lib/utils/name';
 
 const CustomerPlanSummary = ({ planId, initialPlan, token }) => {
-  const { plan, loading } = usePlan(planId, {
+  const { plan, loading, toggleAction } = usePlan(planId, {
     initialPlan,
     token
   });
@@ -19,10 +19,13 @@ const CustomerPlanSummary = ({ planId, initialPlan, token }) => {
 
   return (
     <>
-      <h1>{getPossessiveName(firstName, lastName)} shared plan</h1>
+      <PlanHeader firstName={firstName} lastName={lastName} />
       <GoalSummary plan={plan} token={token} />
-      <ActionsList actions={plan.goal?.actions || []} />
-      {<LegalText />}
+      <ActionsList
+        actions={plan.goal?.actions || []}
+        onActionToggled={toggleAction}
+      />
+      <LegalText />
     </>
   );
 };


### PR DESCRIPTION
**What**  
Allows customers to toggle the completion status for an action.

![image](https://user-images.githubusercontent.com/5405916/84149607-a75dae80-aa58-11ea-99c6-d4c2d9e8551d.png)

**Why**  
So that customers can mark actions as completed.

**Anything else?**  
 - The officers part of this is contained within #55.
 - Small amount of tidy up to the customer summary page.
 - Adds Cypress tests for toggling the action status.
