### PR TITLE
Fixes the authorizer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment": "^2.26.0",
     "nanoid": "^3.1.5",
     "next": "^9.4.0",
-    "node-lambda-authorizer": "https://github.com/LBHackney-IT/node-lambda-authorizer.git#efd5de6",
+    "node-lambda-authorizer": "https://github.com/LBHackney-IT/node-lambda-authorizer.git#0fe9e75",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "restana": "^4.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8600,9 +8600,9 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
-"node-lambda-authorizer@https://github.com/LBHackney-IT/node-lambda-authorizer.git#efd5de6":
+"node-lambda-authorizer@https://github.com/LBHackney-IT/node-lambda-authorizer.git#0fe9e75":
   version "1.0.4"
-  resolved "https://github.com/LBHackney-IT/node-lambda-authorizer.git#efd5de69f7e7c473527c66be3e7016582af6d33b"
+  resolved "https://github.com/LBHackney-IT/node-lambda-authorizer.git#0fe9e7514882c8ffb4182fa984ee10b99bfd886c"
   dependencies:
     cookie "^0.4.0"
     jsonwebtoken "^8.5.1"


### PR DESCRIPTION
**What**  
Updates the node-lambda-authorizer dependency commit hash.

**Why**  
The build is broken as the referenced commit doesn't appear to exist any more.