### PR TITLE
Store officer names for "Agreed with" section

### DIFF
--- a/components/Feature/GoalSummary/index.js
+++ b/components/Feature/GoalSummary/index.js
@@ -1,10 +1,9 @@
 import Panel from 'components/Form/Panel';
-import { getUsername } from 'lib/utils/token';
 import { convertIsoDateToString } from 'lib/utils/date';
 import css from './index.module.scss';
 
-const GoalSummary = ({ token, plan }) => {
-  const user = getUsername(token);
+const GoalSummary = ({ plan }) => {
+  const agreedWith = plan.goal.agreedWithName;
 
   return (
     <Panel>
@@ -16,7 +15,7 @@ const GoalSummary = ({ token, plan }) => {
               {plan.goal.text}
             </p>
             <p className={css['note-text']}>
-              Agreed by {plan.firstName} {plan.lastName} and {user} on{' '}
+              Agreed by {plan.firstName} {plan.lastName} and {agreedWith} on{' '}
               {convertIsoDateToString(plan.goal.agreedDate)}
             </p>
           </div>
@@ -40,7 +39,7 @@ const GoalSummary = ({ token, plan }) => {
           <p data-testid="resident-name-test">
             {plan.firstName} {plan.lastName}
           </p>
-          <p data-testid="user-name-test">{user}</p>
+          <p data-testid="agreedWith-name-test">{agreedWith}</p>
         </div>
       </div>
     </Panel>

--- a/components/Feature/GoalSummary/index.test.js
+++ b/components/Feature/GoalSummary/index.test.js
@@ -1,25 +1,21 @@
 import { render } from '@testing-library/react';
 import GoalSummary from './index';
-import { getUsername } from 'lib/utils/token';
-jest.mock('lib/utils/token');
 
 describe('GoalSummary', () => {
   it('renders the goal summary', () => {
     const username = 'Matt';
-    getUsername.mockReturnValue(username);
-    const token = 'TOKEN';
     const text = 'this is a the goal';
     const targetReviewDate = '2022-10-20T00:00:00.000Z';
     const plan = {
       goal: {
         text,
-        targetReviewDate
+        targetReviewDate,
+        agreedWithName: username
       }
     };
-    const { getByText } = render(<GoalSummary token={token} plan={plan} />);
+    const { getByText } = render(<GoalSummary plan={plan} />);
     expect(getByText(text)).toBeInTheDocument();
     expect(getByText(username)).toBeInTheDocument();
     expect(getByText('20/10/2022')).toBeInTheDocument();
-    expect(getUsername).toHaveBeenCalledWith(token);
   });
 });

--- a/cypress/integration/features/add-action.spec.js
+++ b/cypress/integration/features/add-action.spec.js
@@ -38,7 +38,8 @@ context('Add action form', () => {
         targetReviewDate: '2022-05-29T00:00:00.000Z',
         text: 'some text',
         useAsPhp: false,
-        actions: []
+        actions: [],
+        agreedWithName: 'Ami Working'
       }
     });
 

--- a/cypress/integration/features/add-goal.spec.js
+++ b/cypress/integration/features/add-goal.spec.js
@@ -113,7 +113,7 @@ context('Add-goal form', () => {
         'contain',
         'Dwayn Johnson'
       );
-      cy.get('[data-testid=user-name-test]').should('contain', 'My name');
+      cy.get('[data-testid=agreedWith-name-test]').should('contain', 'My name');
     });
 
     it('Checks the legal text is shown when use as php is ticked', () => {

--- a/cypress/integration/features/share-plan.spec.js
+++ b/cypress/integration/features/share-plan.spec.js
@@ -10,7 +10,8 @@ context('Share the plan with collaborator', () => {
         targetReviewDate: '2022-05-29T00:00:00.000Z',
         text: 'some text',
         useAsPhp: false,
-        actions: []
+        actions: [],
+        agreedWithName: 'Ami Working'
       },
       numbers: ["070000000"],
       emails: ["example@plan.com"],
@@ -27,7 +28,8 @@ context('Share the plan with collaborator', () => {
         targetReviewDate: '2022-05-29T00:00:00.000Z',
         text: 'The goal',
         useAsPhp: true,
-        actions: []
+        actions: [],
+        agreedWithName: 'Ami Working'
       },
       numbers: ["123"],
       emails: ["example2@plan.com"],
@@ -49,46 +51,46 @@ context('Share the plan with collaborator', () => {
         .click()
 
       cy.get('#content > h1')
-        .should('contain','Bart Simpson\'s shared plan');
+        .should('contain', 'Bart Simpson\'s shared plan');
 
       cy.get('#content > h2')
-        .should('contain','Share with collaborators');
+        .should('contain', 'Share with collaborators');
 
       cy.get('#content > table > thead > tr')
-        .should('contain','Collaborators')
-        .and('contain','Share by SMS')
-        .and('contain','Share by email')
-        .and('contain','Share link to plan');
+        .should('contain', 'Collaborators')
+        .and('contain', 'Share by SMS')
+        .and('contain', 'Share by email')
+        .and('contain', 'Share link to plan');
 
       cy.get('[data-testid=collaborator-name-row-test]')
-        .should('contain','Bart Simpson');
+        .should('contain', 'Bart Simpson');
 
       cy.get('[data-testid=share-by-sms-row-test] > div > div > div > input')
-        .should('have.attr','type','checkbox');
+        .should('have.attr', 'type', 'checkbox');
 
       cy.get('[data-testid=share-by-sms-row-test] > div > div > div > input')
         .click();
 
       cy.get('[data-testid=share-by-sms-row-test] > div > div > div > label')
-        .should('contain','+4470000000');
+        .should('contain', '+4470000000');
 
       cy.get('[data-testid=share-by-email-row-test] > div > div > div > input')
-        .should('have.attr','type', 'checkbox');
+        .should('have.attr', 'type', 'checkbox');
 
       cy.get('[data-testid=share-by-email-row-test] > div > div > div > label')
-        .should('contain','example@plan.com');
+        .should('contain', 'example@plan.com');
 
       cy.get('[data-testid=share-link-to-plan-row-test] > span')
-        .should('contain','Not yet shared with Bart');
+        .should('contain', 'Not yet shared with Bart');
 
       cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
-        .should('contain','Share')
+        .should('contain', 'Share')
       cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
         .click();
-      cy.get('#content').should('contain','Last shared with');
+      cy.get('#content').should('contain', 'Last shared with');
     });
 
-    it ('Shows an error when the sms is not sent', () => {
+    it('Shows an error when the sms is not sent', () => {
       cy.visit('http://localhost:3000/plans/2/share');
 
       cy.get('[data-testid=share-by-sms-row-test] > div > div > div > input')
@@ -97,17 +99,17 @@ context('Share the plan with collaborator', () => {
       cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
         .click();
 
-      cy.get('#content').should('contain','Something went wrong. The plan could not be shared.');
+      cy.get('#content').should('contain', 'Something went wrong. The plan could not be shared.');
     })
 
 
-    it ('Shows a warning when no sharing option is selected', () => {
+    it('Shows a warning when no sharing option is selected', () => {
       cy.visit('http://localhost:3000/plans/2/share');
 
 
       cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
         .click();
 
-      cy.get('#content').should('contain','Please select at least one sharing option');
+      cy.get('#content').should('contain', 'Please select at least one sharing option');
     })
-}
+  }

--- a/cypress/integration/features/toggle-action.spec.js
+++ b/cypress/integration/features/toggle-action.spec.js
@@ -18,7 +18,8 @@ context('with no completed actions', () => {
             dueDate: '2020-05-20',
             isCompleted: false
           }
-        ]
+        ],
+        agreedWithName: 'Ami Working'
       }
     });
 

--- a/cypress/integration/pages/summary.spec.js
+++ b/cypress/integration/pages/summary.spec.js
@@ -11,7 +11,8 @@ context('Summary page', () => {
       goal: {
         targetReviewDate: '2022-05-29T00:00:00.000Z',
         text: 'some text',
-        useAsPhp: false
+        useAsPhp: false,
+        agreedWithName: 'Ami Working'
       }
     });
   });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -28,7 +28,7 @@ function terminalLog(violations) {
   cy.task(
     'log',
     `${violations.length} accessibility violation${
-      violations.length === 1 ? '' : 's'
+    violations.length === 1 ? '' : 's'
     } ${violations.length === 1 ? 'was' : 'were'} detected`
   );
   // pluck specific keys to keep the table readable
@@ -50,7 +50,10 @@ const setHackneyCookie = isValidGroup => {
   const group = isValidGroup
     ? 'housingneeds-singleview-beta'
     : 'some-other-group';
-  const token = jwt.sign({name: 'My name', groups: [group] }, 'a-secure-signature');
+  const token = jwt.sign(
+    { name: 'My name', groups: [group] },
+    'a-secure-signature'
+  );
   cy.setCookie('hackneyToken', token, {
     url: 'http://localhost:3000',
     domain: 'localhost'

--- a/lib/domain/goal.js
+++ b/lib/domain/goal.js
@@ -3,13 +3,21 @@ import { Action, ActionNotFoundError } from 'lib/domain';
 const findActionById = actionId => action => action.id === actionId;
 
 export default class Goal {
-  constructor({ agreedDate, targetReviewDate, text, useAsPhp, actions }) {
+  constructor({
+    agreedDate,
+    targetReviewDate,
+    text,
+    useAsPhp,
+    actions,
+    agreedWithName
+  }) {
     this.agreedDate = agreedDate ? agreedDate : todaysDate();
     this.completedDate = null;
     this.targetReviewDate = reviewDate(targetReviewDate);
     this.text = text;
     this.useAsPhp = useAsPhp;
     this.actions = actions || [];
+    this.agreedWithName = agreedWithName || null;
   }
 
   findActionById(actionId) {

--- a/lib/domain/goal.test.js
+++ b/lib/domain/goal.test.js
@@ -8,6 +8,7 @@ describe('Goal', () => {
       agreedDate: '2020-06-05T08:50:00+0000',
       targetReviewDate: '2020-06-05T08:50:00+0000',
       text: 'World peace',
+      agreedWithName: 'Tess Testing',
       actions: [
         new Action({
           id: 'PPBqWA9',

--- a/lib/use-cases/add-goal.js
+++ b/lib/use-cases/add-goal.js
@@ -5,7 +5,7 @@ export default class AddGoal {
     this.planGateway = planGateway;
   }
 
-  async execute({ planId, goal }) {
+  async execute({ planId, goal, currentUserName }) {
     const existingPlan = await this.planGateway.get({ id: planId });
 
     if (!existingPlan) {
@@ -16,7 +16,8 @@ export default class AddGoal {
       targetReviewDate: goal.targetReviewDate,
       text: goal.text,
       useAsPhp: goal.useAsPhp,
-      actions: goal.actions
+      actions: goal.actions,
+      agreedWithName: currentUserName
     });
 
     return await this.planGateway.save({ plan: existingPlan });

--- a/lib/use-cases/add-goal.test.js
+++ b/lib/use-cases/add-goal.test.js
@@ -18,11 +18,13 @@ describe('Add Goal Use Case', () => {
     };
     const useAsPhp = true;
     const actions = [{ summary: 'hello' }];
+    const agreedWithName = 'Tess Ting';
     const addGoal = new AddGoal({ planGateway });
 
     const result = await addGoal.execute({
       planId,
-      goal: { targetReviewDate, text, useAsPhp, actions }
+      goal: { targetReviewDate, text, useAsPhp, actions },
+      currentUserName: agreedWithName
     });
 
     expect(planGateway.get).toHaveBeenCalledWith({ id: planId });
@@ -30,8 +32,8 @@ describe('Add Goal Use Case', () => {
       plan: expect.any(Plan)
     });
     expect(result.id).toEqual(planId);
-    expect(result.goal.toString()).toEqual(
-      new Goal({ targetReviewDate, text, useAsPhp }).toString()
+    expect(result.goal).toEqual(
+      new Goal({ targetReviewDate, text, useAsPhp, actions, agreedWithName })
     );
   });
 

--- a/pages/api/plans/[id]/goals.js
+++ b/pages/api/plans/[id]/goals.js
@@ -1,12 +1,14 @@
 import { addGoal } from 'lib/dependencies';
 import { ArgumentError } from 'lib/domain';
 import { logger } from 'lib/infrastructure/logging';
+import { getUsername, getToken } from 'lib/utils/token';
 
 export const endpoint = ({ addGoal }) => async (req, res) => {
   try {
     const result = await addGoal.execute({
       planId: req.query.id,
-      goal: req.body
+      goal: req.body,
+      currentUserName: getUsername(getToken(req))
     });
 
     res.status(200).json(result);

--- a/pages/api/plans/[id]/goals.test.js
+++ b/pages/api/plans/[id]/goals.test.js
@@ -1,5 +1,7 @@
 import { endpoint } from 'pages/api/plans/[id]/goals';
 import { ArgumentError } from 'lib/domain';
+import { getUsername } from 'lib/utils/token';
+jest.mock('lib/utils/token');
 
 describe('Add goal API', () => {
   let json;
@@ -12,6 +14,7 @@ describe('Add goal API', () => {
         return { json };
       })
     };
+    getUsername.mockReturnValue('Ami Working');
   });
 
   const planId = '1';
@@ -37,7 +40,11 @@ describe('Add goal API', () => {
 
     await endpoint({ addGoal })(req, res);
 
-    expect(addGoal.execute).toHaveBeenCalledWith({ planId, goal });
+    expect(addGoal.execute).toHaveBeenCalledWith({
+      planId,
+      goal,
+      currentUserName: 'Ami Working'
+    });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(json).toHaveBeenCalledWith(expectedResponse);
   });

--- a/pages/customer/plans/[id].js
+++ b/pages/customer/plans/[id].js
@@ -20,7 +20,7 @@ const CustomerPlanSummary = ({ planId, initialPlan, token }) => {
   return (
     <>
       <PlanHeader firstName={firstName} lastName={lastName} />
-      <GoalSummary plan={plan} token={token} />
+      <GoalSummary plan={plan} />
       <ActionsList
         actions={plan.goal?.actions || []}
         onActionToggled={toggleAction}

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -35,7 +35,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
           }}
         />
       )}
-      {!editGoal && <GoalSummary plan={plan} token={token} />}
+      {!editGoal && <GoalSummary plan={plan} />}
       {!editGoal && (
         <Button
           text="Edit goal"


### PR DESCRIPTION
**What**  
Stores the name of the officer that created a plan at the time of creation. This is an update to the existing implementation that fetches the name of the current authenticated user when displaying the plan.

<img src="https://user-images.githubusercontent.com/5405916/84170624-ce74aa00-aa71-11ea-805e-97882de3b6e3.png" width="50%" />

**Why**  
So that we can display this to customers and other members of staff that are viewing the plan in the future consistently.
