### PR TITLE
Ensures token is passed to toggleAction hook

### DIFF
--- a/api/usePlan.js
+++ b/api/usePlan.js
@@ -44,7 +44,7 @@ export function usePlan(planId, { initialPlan, token, ...options } = {}) {
       });
     }),
     toggleAction: withErrorHandling(async ({ actionId, isCompleted }) => {
-      await requestUpdateAction(planId, actionId, { isCompleted });
+      await requestUpdateAction(planId, actionId, { isCompleted }, { token });
       mutate();
     }),
     sharePlan: withErrorHandling(async collaborator => {

--- a/api/usePlan.test.js
+++ b/api/usePlan.test.js
@@ -105,7 +105,8 @@ describe('usePlan', () => {
 
   it('updates the completed state of an action', async () => {
     const actionId = 'PPBqWA9';
-    const { result } = renderHook(() => usePlan(expectedPlan.id));
+    const token = 'a.very.secure.jwt';
+    const { result } = renderHook(() => usePlan(expectedPlan.id, { token }));
 
     await act(() =>
       result.current.toggleAction({
@@ -118,7 +119,10 @@ describe('usePlan', () => {
       expect.stringContaining(`/plans/${expectedPlan.id}/actions/${actionId}`),
       expect.objectContaining({
         method: 'PATCH',
-        body: JSON.stringify({ isCompleted: true })
+        body: JSON.stringify({ isCompleted: true }),
+        headers: expect.objectContaining({
+          authorization: `Bearer ${token}`
+        })
       })
     );
   });


### PR DESCRIPTION
**What**  
Ensures token is passed on requests made by `toggleAction` in the `usePlan` hook.

**Why**  
So that customers, who do not have a cookie set, are able to toggle action status.