### PR TITLE
Stops overwriting entire goal when adding actions

### DIFF
--- a/lib/use-cases/add-action.js
+++ b/lib/use-cases/add-action.js
@@ -17,13 +17,6 @@ export default class AddAction {
       throw new Error('no goal found');
     }
 
-    existingPlan.goal = new Goal({
-      targetReviewDate: existingPlan.goal.targetReviewDate || '',
-      text: existingPlan.goal.text || '',
-      useAsPhp: existingPlan.goal.useAsPhp || false,
-      actions: existingPlan.goal.actions
-    });
-
     existingPlan.goal.addOrReplaceAction(
       new Action({
         id: nanoid(7),


### PR DESCRIPTION
**What**  
Fixes a bug where adding an action will null out the "agreedWithName" field of the goal, since it creates a new goal instance instead of using the existing goal.

**Why**  
So that new fields added to goal are not removed when adding an action.

**Anything else?**  
 - This used to be required as we did not hydrate Plan objects correctly as we retrieved them from the database (the goal was a plain object, not a Goal instance) and so we could not call methods on it's children. This is now fixed, as a result of the mapping changes in #55.
