### PR TITLE
Shorten the plan urls

### DIFF
--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -8,7 +8,6 @@ import {
 } from './models';
 
 class PlanGateway {
-
   constructor({ client, tableName }) {
     this.client = client;
     this.tableName = tableName;
@@ -19,7 +18,7 @@ class PlanGateway {
     if (!lastName) throw new ArgumentError('last name cannot be null.');
 
     const plan = new Plan({
-      id: nanoid(20),
+      id: nanoid(6),
       firstName,
       lastName,
       systemIds: systemIds,

--- a/lib/gateways/plan-gateway.test.js
+++ b/lib/gateways/plan-gateway.test.js
@@ -57,7 +57,7 @@ describe('Plan Gateway', () => {
       expect(client.put).toHaveBeenCalledWith(expectedRequest);
       expect(result).toBeInstanceOf(Plan);
       expect(result.id).toStrictEqual(expect.any(String));
-      expect(result.id.length).toBe(20);
+      expect(result.id.length).toBe(6);
       expect(result.firstName).toEqual(firstName);
       expect(result.lastName).toEqual(lastName);
     });

--- a/lib/use-cases/add-action.js
+++ b/lib/use-cases/add-action.js
@@ -19,7 +19,7 @@ export default class AddAction {
 
     existingPlan.goal.addOrReplaceAction(
       new Action({
-        id: nanoid(7),
+        id: nanoid(6),
         ...action
       })
     );

--- a/lib/use-cases/share-plan.js
+++ b/lib/use-cases/share-plan.js
@@ -11,13 +11,13 @@ export default class SharePlan {
     const existingPlan = await this.planGateway.get({ id: planId });
 
     const newToken = new Token({
-      token: nanoid(10)
+      token: nanoid(6)
     });
 
     if (!existingPlan.customerTokens) existingPlan.customerTokens = [];
     existingPlan.customerTokens.push(newToken);
 
-    const planUrl = `${process.env.NEXT_PUBLIC_URL}/customer/plans/${existingPlan.id}?token=${newToken.token}`;
+    const planUrl = `${process.env.NEXT_PUBLIC_URL}/c/plans/${existingPlan.id}?token=${newToken.token}`;
 
     if (collaborator.number) {
       const message = `You've been sent a link to your Shared Plan from Hackney Council. Click here to view: ${planUrl}`;

--- a/lib/use-cases/share-plan.test.js
+++ b/lib/use-cases/share-plan.test.js
@@ -56,7 +56,7 @@ describe('Share plan', () => {
     const expectedSmsRequest = {
       authHeader,
       message: expect.stringContaining(
-        `${process.env.NEXT_PUBLIC_URL}/customer/plans/${planId}?token=random_string`
+        `${process.env.NEXT_PUBLIC_URL}/c/plans/${planId}?token=random_string`
       ),
       name: `${firstName} ${lastName}`,
       number

--- a/router/lambda.js
+++ b/router/lambda.js
@@ -43,7 +43,7 @@ const authoriseStaffHandler = (req, res, next) => {
 
 // private customer routes
 server.all(
-  '/customer/plans/:id',
+  '/c/plans/:id',
   (req, res, next) => authoriseCustomerHandler(req, res, next),
   (req, res) => nextRequestHandler(req, res)
 );


### PR DESCRIPTION
**What**  
- Update generated id's to be 6 chars long
- Change customer route prefix from '/customer' to '/c'

**Why**  
To shorten the urls we share
