### PR TITLE
Tick use as a PHP if user has PHP record in Singleview

### DIFF
--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -10,7 +10,8 @@ const AddGoal = ({ goal, hasPhp, onGoalAdded }) => {
       ? convertIsoDateToObject(goal.targetReviewDate)
       : { day: '', month: '', year: '' }
   );
-  const [useAsPhp, setUseAsPhp] = useState(hasPhp);
+  !goal ? hasPhp : goal.useAsPhp;
+  const [useAsPhp, setUseAsPhp] = useState(!goal ? hasPhp : goal.useAsPhp);
   const [validate, setValidate] = useState(false);
   const actions = goal?.actions || [];
 

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -3,14 +3,14 @@ import moment from 'moment';
 import { Button, Checkbox, DateInput, TextInput } from 'components/Form';
 import { convertIsoDateToObject } from 'lib/utils/date';
 
-const AddGoal = ({ goal, onGoalAdded }) => {
+const AddGoal = ({ goal, hasPhp, onGoalAdded }) => {
   const [text, setGoalText] = useState(goal?.text || '');
   const [targetReviewDate, setTargetReviewDate] = useState(
     goal && goal.targetReviewDate
       ? convertIsoDateToObject(goal.targetReviewDate)
       : { day: '', month: '', year: '' }
   );
-  const [useAsPhp, setUseAsPhp] = useState(goal?.useAsPhp || false);
+  const [useAsPhp, setUseAsPhp] = useState(hasPhp);
   const [validate, setValidate] = useState(false);
   const actions = goal?.actions || [];
 

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -3,15 +3,16 @@ import moment from 'moment';
 import { Button, Checkbox, DateInput, TextInput } from 'components/Form';
 import { convertIsoDateToObject } from 'lib/utils/date';
 
-const AddGoal = ({ goal, hasPhp, onGoalAdded }) => {
+const AddGoal = ({ goal, initialUseAsPhp, onGoalAdded }) => {
   const [text, setGoalText] = useState(goal?.text || '');
   const [targetReviewDate, setTargetReviewDate] = useState(
     goal && goal.targetReviewDate
       ? convertIsoDateToObject(goal.targetReviewDate)
       : { day: '', month: '', year: '' }
   );
-  !goal ? hasPhp : goal.useAsPhp;
-  const [useAsPhp, setUseAsPhp] = useState(!goal ? hasPhp : goal.useAsPhp);
+  const [useAsPhp, setUseAsPhp] = useState(
+    !goal ? initialUseAsPhp : goal.useAsPhp
+  );
   const [validate, setValidate] = useState(false);
   const actions = goal?.actions || [];
 

--- a/components/Feature/AddGoal/index.test.js
+++ b/components/Feature/AddGoal/index.test.js
@@ -15,7 +15,7 @@ describe('AddGoal', () => {
   it('saves the goal when add actions button is clicked', () => {
     const onGoalAdded = jest.fn();
     const { getByLabelText, getByText } = render(
-      <AddGoal onGoalAdded={onGoalAdded} />
+      <AddGoal hasPhp={false} onGoalAdded={onGoalAdded} />
     );
 
     fireEvent.change(getByLabelText('Goal'), {
@@ -82,6 +82,11 @@ describe('AddGoal', () => {
 
   it('sets the use as php input value if goal already exists', () => {
     const { getByLabelText } = render(<AddGoal goal={{ useAsPhp: true }} />);
+    expect(getByLabelText('Use as a PHP').checked).toEqual(true);
+  });
+
+  it('checks use as PHP checkbox if resident has PHP record in singleview', () => {
+    const { getByLabelText } = render(<AddGoal hasPhp={true} />);
     expect(getByLabelText('Use as a PHP').checked).toEqual(true);
   });
 });

--- a/components/Feature/AddGoal/index.test.js
+++ b/components/Feature/AddGoal/index.test.js
@@ -15,7 +15,7 @@ describe('AddGoal', () => {
   it('saves the goal when add actions button is clicked', () => {
     const onGoalAdded = jest.fn();
     const { getByLabelText, getByText } = render(
-      <AddGoal hasPhp={false} onGoalAdded={onGoalAdded} />
+      <AddGoal initialUseAsPhp={false} onGoalAdded={onGoalAdded} />
     );
 
     fireEvent.change(getByLabelText('Goal'), {
@@ -86,7 +86,7 @@ describe('AddGoal', () => {
   });
 
   it('checks use as PHP checkbox if resident has PHP record in singleview', () => {
-    const { getByLabelText } = render(<AddGoal hasPhp={true} />);
+    const { getByLabelText } = render(<AddGoal initialUseAsPhp={true} />);
     expect(getByLabelText('Use as a PHP').checked).toEqual(true);
   });
 });

--- a/cypress/integration/features/add-goal.spec.js
+++ b/cypress/integration/features/add-goal.spec.js
@@ -1,7 +1,5 @@
 /// <reference types="cypress" />
 
-import { createPlan } from 'lib/dependencies';
-
 context('Add-goal form', () => {
   const createGoal = (goalText, day, month, year, useAsPhp) => {
     if (goalText) {
@@ -36,7 +34,7 @@ context('Add-goal form', () => {
       lastName: 'Johnson',
       queryFirstName: 'dwayn',
       queryLastName: 'johnson',
-      hasPhp: false
+      initialUseAsPhp: false
     });
 
     cy.task('createPlan', {
@@ -45,7 +43,7 @@ context('Add-goal form', () => {
       lastName: 'Sandman',
       queryFirstName: 'mr',
       queryLastName: 'sandman',
-      hasPhp: true
+      initialUseAsPhp: true
     });
 
     cy.setHackneyCookie(true);

--- a/cypress/integration/features/add-goal.spec.js
+++ b/cypress/integration/features/add-goal.spec.js
@@ -1,5 +1,7 @@
 /// <reference types="cypress" />
 
+import { createPlan } from 'lib/dependencies';
+
 context('Add-goal form', () => {
   const createGoal = (goalText, day, month, year, useAsPhp) => {
     if (goalText) {
@@ -33,7 +35,17 @@ context('Add-goal form', () => {
       firstName: 'Dwayn',
       lastName: 'Johnson',
       queryFirstName: 'dwayn',
-      queryLastName: 'johnson'
+      queryLastName: 'johnson',
+      hasPhp: false
+    });
+
+    cy.task('createPlan', {
+      id: '3',
+      firstName: 'Mr',
+      lastName: 'Sandman',
+      queryFirstName: 'mr',
+      queryLastName: 'sandman',
+      hasPhp: true
     });
 
     cy.setHackneyCookie(true);
@@ -42,6 +54,7 @@ context('Add-goal form', () => {
 
   afterEach(() => {
     cy.task('deletePlan', '2');
+    cy.task('deletePlan', '3');
   });
 
   describe('Add goal', () => {
@@ -142,6 +155,32 @@ context('Add-goal form', () => {
         'not.contain',
         'Use as a PHP'
       );
+    });
+
+    it.only('Checks that use as a php box is ticked when customer has php record in Singleview', () => {
+      cy.visit(`http://localhost:3000/plans/3`);
+      createGoal('This is the goal', '23', '12', '2025', '');
+      cy.get('#use-as-php').should('have.attr', 'checked');
+      cy.get('[data-testid=add-actions-button-test]').click();
+      cy.get('[data-testid=legal-text-test]').should(
+        'contain',
+        'About this plan'
+      );
+      cy.get('[data-testid=edit-goal-button-test]').click();
+      cy.get('#use-as-php').should('have.attr', 'checked');
+    });
+
+    it.only('Checks that use as a php box is not ticked when customer does not have php record in Singleview', () => {
+      cy.visit(`http://localhost:3000/plans/2`);
+      createGoal('This is the goal', '23', '12', '2025', '');
+      cy.get('#use-as-php').should('not.have.attr', 'checked');
+      cy.get('[data-testid=add-actions-button-test]').click();
+      cy.get('[data-testid=legal-text-test]').should(
+        'not.contain',
+        'About this plan'
+      );
+      cy.get('[data-testid=edit-goal-button-test]').click();
+      cy.get('#use-as-php').should('not.have.attr', 'checked');
     });
   });
 });

--- a/lib/domain/plan.js
+++ b/lib/domain/plan.js
@@ -8,7 +8,8 @@ export default class Plan {
     systemIds,
     numbers,
     emails,
-    customerTokens
+    customerTokens,
+    hasPhp
   }) {
     this.id = id;
     this.created = created ? created : new Date(Date.now()).toISOString();
@@ -19,5 +20,6 @@ export default class Plan {
     this.numbers = numbers || [];
     this.emails = emails || [];
     this.customerTokens = customerTokens || [];
+    this.hasPhp = hasPhp;
   }
 }

--- a/lib/domain/plan.js
+++ b/lib/domain/plan.js
@@ -9,7 +9,7 @@ export default class Plan {
     numbers,
     emails,
     customerTokens,
-    hasPhp
+    initialUseAsPhp
   }) {
     this.id = id;
     this.created = created ? created : new Date(Date.now()).toISOString();
@@ -20,6 +20,6 @@ export default class Plan {
     this.numbers = numbers || [];
     this.emails = emails || [];
     this.customerTokens = customerTokens || [];
-    this.hasPhp = hasPhp;
+    this.initialUseAsPhp = initialUseAsPhp;
   }
 }

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -8,13 +8,12 @@ import {
 } from './models';
 
 class PlanGateway {
-
   constructor({ client, tableName }) {
     this.client = client;
     this.tableName = tableName;
   }
 
-  async create({ firstName, lastName, systemIds, emails, numbers }) {
+  async create({ firstName, lastName, systemIds, emails, numbers, hasPhp }) {
     if (!firstName) throw new ArgumentError('first name cannot be null.');
     if (!lastName) throw new ArgumentError('last name cannot be null.');
 
@@ -24,7 +23,8 @@ class PlanGateway {
       lastName,
       systemIds: systemIds,
       emails: emails,
-      numbers: numbers
+      numbers: numbers,
+      hasPhp: hasPhp
     });
 
     const request = {

--- a/lib/gateways/plan-gateway.js
+++ b/lib/gateways/plan-gateway.js
@@ -13,7 +13,14 @@ class PlanGateway {
     this.tableName = tableName;
   }
 
-  async create({ firstName, lastName, systemIds, emails, numbers, hasPhp }) {
+  async create({
+    firstName,
+    lastName,
+    systemIds,
+    emails,
+    numbers,
+    initialUseAsPhp
+  }) {
     if (!firstName) throw new ArgumentError('first name cannot be null.');
     if (!lastName) throw new ArgumentError('last name cannot be null.');
 
@@ -24,7 +31,7 @@ class PlanGateway {
       systemIds: systemIds,
       emails: emails,
       numbers: numbers,
-      hasPhp: hasPhp
+      initialUseAsPhp: initialUseAsPhp
     });
 
     const request = {

--- a/lib/use-cases/create-plan.js
+++ b/lib/use-cases/create-plan.js
@@ -3,13 +3,14 @@ export default class CreatePlan {
     this.planGateway = planGateway;
   }
 
-  async execute({ firstName, lastName, systemIds, numbers, emails }) {
+  async execute({ firstName, lastName, systemIds, numbers, emails, hasPhp }) {
     const plan = await this.planGateway.create({
       firstName,
       lastName,
       systemIds,
       emails,
-      numbers
+      numbers,
+      hasPhp
     });
 
     return {

--- a/lib/use-cases/create-plan.js
+++ b/lib/use-cases/create-plan.js
@@ -3,14 +3,21 @@ export default class CreatePlan {
     this.planGateway = planGateway;
   }
 
-  async execute({ firstName, lastName, systemIds, numbers, emails, hasPhp }) {
+  async execute({
+    firstName,
+    lastName,
+    systemIds,
+    numbers,
+    emails,
+    initialUseAsPhp
+  }) {
     const plan = await this.planGateway.create({
       firstName,
       lastName,
       systemIds,
       emails,
       numbers,
-      hasPhp
+      initialUseAsPhp
     });
 
     return {

--- a/pages/api/plans/index.js
+++ b/pages/api/plans/index.js
@@ -11,7 +11,7 @@ export const endpoint = ({ createPlan }) => async (req, res) => {
         systemIds: req.body.systemIds,
         numbers: req.body.numbers,
         emails: req.body.emails,
-        hasPhp: req.body.hasPhp
+        initialUseAsPhp: req.body.initialUseAsPhp
       });
       logger.info(`Success`, { result });
 

--- a/pages/api/plans/index.js
+++ b/pages/api/plans/index.js
@@ -10,7 +10,8 @@ export const endpoint = ({ createPlan }) => async (req, res) => {
         lastName: req.body.lastName,
         systemIds: req.body.systemIds,
         numbers: req.body.numbers,
-        emails: req.body.emails
+        emails: req.body.emails,
+        hasPhp: req.body.hasPhp
       });
       logger.info(`Success`, { result });
 

--- a/pages/api/plans/index.test.js
+++ b/pages/api/plans/index.test.js
@@ -5,6 +5,7 @@ describe('Create Plan Api', () => {
   const firstName = 'James';
   const lastName = 'Bond';
   const systemIds = ['xyz'];
+  const hasPhp = true;
 
   let json;
   let res;
@@ -23,7 +24,8 @@ describe('Create Plan Api', () => {
     body: {
       firstName,
       lastName,
-      systemIds
+      systemIds,
+      hasPhp
     }
   };
 
@@ -32,7 +34,8 @@ describe('Create Plan Api', () => {
     const expectedResponse = expect.objectContaining({
       id,
       firstName,
-      lastName
+      lastName,
+      hasPhp
     });
 
     const createPlan = {
@@ -44,7 +47,8 @@ describe('Create Plan Api', () => {
     expect(createPlan.execute).toHaveBeenCalledWith({
       firstName,
       lastName,
-      systemIds
+      systemIds,
+      hasPhp
     });
     expect(res.status).toHaveBeenCalledWith(201);
     expect(json).toHaveBeenCalledWith(expectedResponse);

--- a/pages/api/plans/index.test.js
+++ b/pages/api/plans/index.test.js
@@ -5,7 +5,7 @@ describe('Create Plan Api', () => {
   const firstName = 'James';
   const lastName = 'Bond';
   const systemIds = ['xyz'];
-  const hasPhp = true;
+  const initialUseAsPhp = true;
 
   let json;
   let res;
@@ -25,7 +25,7 @@ describe('Create Plan Api', () => {
       firstName,
       lastName,
       systemIds,
-      hasPhp
+      initialUseAsPhp
     }
   };
 
@@ -35,7 +35,7 @@ describe('Create Plan Api', () => {
       id,
       firstName,
       lastName,
-      hasPhp
+      initialUseAsPhp
     });
 
     const createPlan = {
@@ -48,7 +48,7 @@ describe('Create Plan Api', () => {
       firstName,
       lastName,
       systemIds,
-      hasPhp
+      initialUseAsPhp
     });
     expect(res.status).toHaveBeenCalledWith(201);
     expect(json).toHaveBeenCalledWith(expectedResponse);

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -40,6 +40,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
       {!editGoal && (
         <Button
           text="Edit goal"
+          data-testid="edit-goal-button-test"
           isSecondary={true}
           onClick={() => setEditGoal(true)}
         />

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -21,7 +21,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
 
   const [editGoal, setEditGoal] = useState(!plan.goal ? true : false);
   const [showAddAction, setShowAddAction] = useState(false);
-  const { firstName, lastName, goal, hasPhp } = plan;
+  const { firstName, lastName, goal, initialUseAsPhp } = plan;
 
   return (
     <>
@@ -29,7 +29,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
       {editGoal && (
         <AddGoal
           goal={goal}
-          hasPhp={hasPhp}
+          initialUseAsPhp={initialUseAsPhp}
           onGoalAdded={async goal => {
             await addGoal(goal);
             setEditGoal(false);

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -21,7 +21,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
 
   const [editGoal, setEditGoal] = useState(!plan.goal ? true : false);
   const [showAddAction, setShowAddAction] = useState(false);
-  const { firstName, lastName, goal } = plan;
+  const { firstName, lastName, goal, hasPhp } = plan;
 
   return (
     <>
@@ -29,6 +29,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
       {editGoal && (
         <AddGoal
           goal={goal}
+          hasPhp={hasPhp}
           onGoalAdded={async goal => {
             await addGoal(goal);
             setEditGoal(false);
@@ -67,7 +68,11 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
         />
       )}
       {!editGoal && (
-        <a className="govuk-button" href={`/plans/${planId}/share`} data-testid="share-plan-button-test">
+        <a
+          className="govuk-button"
+          href={`/plans/${planId}/share`}
+          data-testid="share-plan-button-test"
+        >
           Share plan
         </a>
       )}


### PR DESCRIPTION
**What**  
Creates a plan with useAsPhp ticked in the add goal form if resident has php in Singleview.

**Why**  
To inform the user that the customer has a PHP record.

**Anything else?**  
 - Have you added any new third-party libraries? No.
 - Are any new environment variables or configuration values needed? No.
 - Anything else in this PR that isn't covered by the what/why? No.
