### PR TITLE
Adds API support for deleting an action

### DIFF
--- a/lib/api/createEndpoint.js
+++ b/lib/api/createEndpoint.js
@@ -11,7 +11,7 @@ export function createEndpoint({ allowedMethods, validators }, endpoint) {
       return response.body ? res.send(response.body) : res.end();
     }
 
-    const request = { params: req.query, body: req.body };
+    const request = { params: req.query, body: req.body, method: req.method };
 
     if (!allowedMethods.includes(req.method)) {
       return send(Response.notAllowed());

--- a/lib/dependencies.js
+++ b/lib/dependencies.js
@@ -5,6 +5,7 @@ import CreatePlan from './use-cases/create-plan';
 import FindPlans from './use-cases/find-plans';
 import SharePlan from './use-cases/share-plan';
 import UpdateAction from './use-cases/update-action';
+import DeleteAction from './use-cases/delete-action';
 import PlanGateway from './gateways/plan-gateway';
 import SmsGateway from './gateways/sms-gateway';
 import { logger, withLogging } from './infrastructure/logging';
@@ -37,6 +38,10 @@ const updateAction = withLogging(
   new UpdateAction({ getPlan, planGateway }),
   logger
 );
+const deleteAction = withLogging(
+  new DeleteAction({ getPlan, planGateway }),
+  logger
+);
 
 export {
   addGoal,
@@ -45,5 +50,6 @@ export {
   findPlans,
   getPlan,
   sharePlan,
-  updateAction
+  updateAction,
+  deleteAction
 };

--- a/lib/domain/goal.js
+++ b/lib/domain/goal.js
@@ -30,6 +30,14 @@ export default class Goal {
     throw new ActionNotFoundError(actionId);
   }
 
+  deleteActionById(actionId) {
+    const existing = this.actions.findIndex(findActionById(actionId));
+
+    if (existing >= 0) {
+      this.actions.splice(existing, 1);
+    }
+  }
+
   addOrReplaceAction(action) {
     if (!(action instanceof Action)) {
       throw new TypeError(

--- a/lib/domain/goal.test.js
+++ b/lib/domain/goal.test.js
@@ -66,6 +66,18 @@ describe('Goal', () => {
     });
   });
 
+  describe('deleteActionById', () => {
+    it('deletes the action, if it exists', () => {
+      goal.deleteActionById('PPBqWA9');
+      expect(goal.actions.length).toBe(0);
+    });
+
+    it('does nothing if the action does not exist', () => {
+      goal.deleteActionById('NOT_FOUND');
+      expect(goal.actions.length).toBe(1);
+    });
+  });
+
   it('sets the agreed date to todays date', () => {
     const today = new Date();
     today.setUTCHours(0, 0, 0, 0);

--- a/lib/use-cases/delete-action.js
+++ b/lib/use-cases/delete-action.js
@@ -1,0 +1,20 @@
+import { PlanNotFoundError } from 'lib/domain';
+
+export default class DeleteAction {
+  constructor({ getPlan, planGateway }) {
+    this.getPlan = getPlan;
+    this.planGateway = planGateway;
+  }
+
+  async execute({ planId, actionId }) {
+    const plan = await this.getPlan.execute({ id: planId });
+
+    if (!plan) {
+      throw new PlanNotFoundError(planId);
+    }
+
+    const { goal } = plan;
+    goal.deleteActionById(actionId);
+    await this.planGateway.save({ plan });
+  }
+}

--- a/lib/use-cases/delete-action.test.js
+++ b/lib/use-cases/delete-action.test.js
@@ -1,0 +1,57 @@
+import UpdateAction from './delete-action';
+import { Action, Goal, Plan, PlanNotFoundError } from 'lib/domain';
+
+describe('DeleteAction', () => {
+  const expectedPlan = new Plan({
+    id: 'd6BQiWGGhOrF8mFdPp4T',
+    created: '2020-05-04T00:00:00+0000',
+    firstName: 'Planella',
+    lastName: 'Plansalot',
+    goal: new Goal({
+      targetReviewDate: '2020-06-04T00:00:00+0000',
+      actions: [
+        new Action({
+          id: 'PPBqWA9',
+          summary: 'Do something',
+          dueDate: '2020-06-04T00:00:00+0000'
+        })
+      ]
+    })
+  });
+
+  const usecase = new UpdateAction({
+    getPlan: { execute: jest.fn() },
+    planGateway: { save: jest.fn(() => Promise.resolve()) }
+  });
+
+  beforeEach(() => {
+    usecase.getPlan.execute.mockImplementation(() =>
+      Promise.resolve(expectedPlan)
+    );
+  });
+
+  describe('execute', () => {
+    it('throws PlanNotFoundError if a plan is not found', () => {
+      usecase.getPlan.execute.mockImplementation(() => Promise.resolve(null));
+      expect(
+        usecase.execute({
+          planId: 'd6BQiWGGhOrF8mFdPp4T',
+          actionId: 'PPBqWA9'
+        })
+      ).rejects.toThrowError(PlanNotFoundError);
+    });
+
+    it('saves the updated plan', async () => {
+      await usecase.execute({
+        planId: 'd6BQiWGGhOrF8mFdPp4T',
+        actionId: 'PPBqWA9'
+      });
+
+      expect(usecase.planGateway.save).toHaveBeenCalledWith({
+        plan: expect.objectContaining({
+          goal: expect.objectContaining({ actions: [] })
+        })
+      });
+    });
+  });
+});

--- a/pages/api/plans/[id]/actions/[actionId].js
+++ b/pages/api/plans/[id]/actions/[actionId].js
@@ -1,6 +1,6 @@
 import Response from 'lib/api/response';
 import { createEndpoint } from 'lib/api/createEndpoint';
-import { updateAction } from 'lib/dependencies';
+import { updateAction, deleteAction } from 'lib/dependencies';
 
 export const endpoint = ({ updateAction, deleteAction }) =>
   createEndpoint(
@@ -40,4 +40,4 @@ export const endpoint = ({ updateAction, deleteAction }) =>
     }
   );
 
-export default endpoint({ updateAction });
+export default endpoint({ updateAction, deleteAction });

--- a/pages/api/plans/[id]/actions/[actionId].test.js
+++ b/pages/api/plans/[id]/actions/[actionId].test.js
@@ -1,4 +1,4 @@
-import { endpoint } from './[actionId]';
+import defaultEndpoint, { endpoint } from './[actionId]';
 import { createMockResponse } from 'lib/api/utils/createMockResponse';
 
 describe('[PATCH|DELETE] /api/plans/[id]/actions/[actionid]', () => {
@@ -14,6 +14,11 @@ describe('[PATCH|DELETE] /api/plans/[id]/actions/[actionid]', () => {
       await call({ method }, response);
       expect(response.statusCode).toBe(405);
     }
+  });
+
+  it('has a default export', () => {
+    // without a default export Next cannot find the endpoint
+    expect(defaultEndpoint).toBeInstanceOf(Function);
   });
 
   describe('validation', () => {


### PR DESCRIPTION
**What**  
Adds the API endpoint to support deleting actions from a goal.

**Why**  
So that officers can delete actions from goals when they have been added in error.

**Anything else?** 
 - This endpoint needs to behave different depending upon the HTTP method, so passed through `method` to the endpoint so that it can run some conditional logic. In an ideal world it would be nice to have separate files for these, but this is a limitation of how Next handles routing out of the box. Given that the logic is pretty simple I don't see this being a huge problem.
