### PR TITLE
Adds support for deleting actions

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -72,3 +72,10 @@ export function requestUpdateAction(planId, actionId, updates, options) {
     ...options
   });
 }
+
+export function requestDeleteAction(planId, actionId, options) {
+  return request(`/plans/${planId}/actions/${actionId}`, {
+    method: 'DELETE',
+    ...options
+  });
+}

--- a/api/usePlan.js
+++ b/api/usePlan.js
@@ -5,7 +5,8 @@ import {
   requestAddGoal,
   requestAddAction,
   requestSharePlan,
-  requestUpdateAction
+  requestUpdateAction,
+  requestDeleteAction
 } from './api';
 
 export function usePlan(planId, { initialPlan, token, ...options } = {}) {
@@ -49,6 +50,10 @@ export function usePlan(planId, { initialPlan, token, ...options } = {}) {
     }),
     toggleAction: withErrorHandling(async ({ actionId, isCompleted }) => {
       await requestUpdateAction(planId, actionId, { isCompleted }, { token });
+      mutate();
+    }),
+    deleteAction: withErrorHandling(async ({ actionId }) => {
+      await requestDeleteAction(planId, actionId, { token });
       mutate();
     }),
     sharePlan: withErrorHandling(async (collaborator, customerPlanUrl) => {

--- a/api/usePlan.test.js
+++ b/api/usePlan.test.js
@@ -139,4 +139,22 @@ describe('usePlan', () => {
       })
     );
   });
+
+  it('deletes an action', async () => {
+    const actionId = 'PPBqWA9';
+    const token = 'a.very.secure.jwt';
+    const { result } = renderHook(() => usePlan(expectedPlan.id, { token }));
+
+    await act(() => result.current.deleteAction({ actionId }));
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(`/plans/${expectedPlan.id}/actions/${actionId}`),
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          authorization: `Bearer ${token}`
+        })
+      })
+    );
+  });
 });

--- a/components/Feature/ActionsList/index.js
+++ b/components/Feature/ActionsList/index.js
@@ -1,5 +1,4 @@
-import Checkbox from 'components/Form/Checkbox';
-import Details from 'components/Form/Details';
+import { Button, ButtonGroup, Checkbox, Details } from 'components/Form';
 import DueDate from './DueDate';
 import Heading from 'components/Heading';
 import Table, {
@@ -10,7 +9,6 @@ import Table, {
   TableData
 } from 'components/Table';
 import styles from './index.module.scss';
-import { Button } from '../../Form';
 
 const ActionsList = ({
   actions,
@@ -80,22 +78,24 @@ const ActionsList = ({
                 </TableData>
                 <TableData className={styles['lbh-actions-list__due-date']}>
                   <DueDate dateTime={action.dueDate} />
-                  {onEditAction && (
-                    <Button
-                      text="Edit"
-                      isSecondary={true}
-                      data-testid="edit-action-button-test"
-                      onClick={() => onEditAction(action.id)}
-                    />
-                  )}
-                  {onActionDeleted && (
-                    <Button
-                      text="Delete"
-                      isSecondary={true}
-                      data-testid={`actions-list-button-delete-${action.id}`}
-                      onClick={() => onActionDeleted({ actionId: action.id })}
-                    />
-                  )}
+                  <ButtonGroup>
+                    {onEditAction && (
+                      <Button
+                        text="Edit"
+                        isSecondary={true}
+                        data-testid="edit-action-button-test"
+                        onClick={() => onEditAction(action.id)}
+                      />
+                    )}
+                    {onActionDeleted && (
+                      <Button
+                        text="Delete"
+                        isSecondary={true}
+                        data-testid={`actions-list-button-delete-${action.id}`}
+                        onClick={() => onActionDeleted({ actionId: action.id })}
+                      />
+                    )}
+                  </ButtonGroup>
                 </TableData>
               </TableRow>
             ))}

--- a/components/Feature/ActionsList/index.js
+++ b/components/Feature/ActionsList/index.js
@@ -12,7 +12,12 @@ import Table, {
 import styles from './index.module.scss';
 import { Button } from '../../Form';
 
-const ActionsList = ({ actions, onActionToggled, onEditAction }) => {
+const ActionsList = ({
+  actions,
+  onActionToggled,
+  onEditAction,
+  onActionDeleted
+}) => {
   return (
     <>
       <Heading as="h2" size="m">
@@ -75,12 +80,22 @@ const ActionsList = ({ actions, onActionToggled, onEditAction }) => {
                 </TableData>
                 <TableData className={styles['lbh-actions-list__due-date']}>
                   <DueDate dateTime={action.dueDate} />
-                  <Button
-                    text="Edit action"
-                    isSecondary={true}
-                    data-testid="edit-action-button-test"
-                    onClick={() => onEditAction(action.id)}
-                  />
+                  {onEditAction && (
+                    <Button
+                      text="Edit"
+                      isSecondary={true}
+                      data-testid="edit-action-button-test"
+                      onClick={() => onEditAction(action.id)}
+                    />
+                  )}
+                  {onActionDeleted && (
+                    <Button
+                      text="Delete"
+                      isSecondary={true}
+                      data-testid={`actions-list-button-delete-${action.id}`}
+                      onClick={() => onActionDeleted({ actionId: action.id })}
+                    />
+                  )}
                 </TableData>
               </TableRow>
             ))}

--- a/components/Feature/ActionsList/index.module.scss
+++ b/components/Feature/ActionsList/index.module.scss
@@ -36,4 +36,8 @@
   @media (max-width: #{$screen-sm-min}) {
     display: none;
   }
+
+  button {
+    margin-top: 0.5em;
+  }
 }

--- a/components/Feature/ActionsList/index.test.js
+++ b/components/Feature/ActionsList/index.test.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 
 describe('<ActionsList />', () => {
   const onActionToggled = jest.fn();
+  const onActionDeleted = jest.fn();
 
   const component = (
     <ActionsList
@@ -22,6 +23,7 @@ describe('<ActionsList />', () => {
         }
       ]}
       onActionToggled={onActionToggled}
+      onActionDeleted={onActionDeleted}
     />
   );
 
@@ -72,5 +74,11 @@ describe('<ActionsList />', () => {
       actionId: 'PPBqWA9',
       isCompleted: false
     });
+  });
+
+  it('triggers "onActionDeleted" when delete button clicked', () => {
+    const { getByTestId } = render(component);
+    getByTestId('actions-list-button-delete-PPBqWA9').click();
+    expect(onActionDeleted).toHaveBeenCalledWith({ actionId: 'PPBqWA9' });
   });
 });

--- a/components/Feature/SharePlan/index.js
+++ b/components/Feature/SharePlan/index.js
@@ -100,6 +100,7 @@ const SharePlan = ({ error, plan, customerUrl, onPlanShared }) => {
               <Button
                 className={`govuk-button ${css['share-link-to-plan__button']}`}
                 data-module="govuk-button"
+                data-testid="share-plan-button"
                 onClick={shareThePlan}
                 text="Share"
               />

--- a/components/Form/Button/index.js
+++ b/components/Form/Button/index.js
@@ -1,16 +1,14 @@
 const Button = ({ onClick, text, isSecondary, ...others }) => (
-  <div className="govuk-form-group">
-    <button
-      className={`govuk-button${
-        isSecondary === true ? ' govuk-button--secondary' : ''
+  <button
+    className={`lbh-button govuk-button${
+      isSecondary ? ' govuk-button--secondary' : ''
       }`}
-      data-module="govuk-button"
-      onClick={onClick}
-      {...others}
-    >
-      {text}
-    </button>
-  </div>
+    data-module="govuk-button"
+    onClick={onClick}
+    {...others}
+  >
+    {text}
+  </button>
 );
 
 export default Button;

--- a/components/Form/ButtonGroup/index.js
+++ b/components/Form/ButtonGroup/index.js
@@ -1,0 +1,7 @@
+import css from './index.module.scss';
+
+const ButtonGroup = ({ children }) => (
+  <div className={css['lbh-button-group']}>{children}</div>
+);
+
+export default ButtonGroup;

--- a/components/Form/ButtonGroup/index.module.scss
+++ b/components/Form/ButtonGroup/index.module.scss
@@ -1,0 +1,5 @@
+.lbh-button-group {
+  button, .govuk-button {
+    margin-right: 0.5em;
+  }
+}

--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -1,9 +1,21 @@
 import Button from './Button';
+import ButtonGroup from './ButtonGroup';
 import Checkbox from './Checkbox';
 import DateInput from './DateInput';
+import Details from './Details';
 import SummaryList from './SummaryList';
 import TextInput from './TextInput';
 import Panel from './Panel';
 import TextArea from './TextArea';
 
-export { Button, Checkbox, DateInput, SummaryList, TextInput, Panel, TextArea };
+export {
+  Button,
+  ButtonGroup,
+  Checkbox,
+  DateInput,
+  Details,
+  SummaryList,
+  TextInput,
+  Panel,
+  TextArea
+};

--- a/cypress/integration/features/delete-action.spec.js
+++ b/cypress/integration/features/delete-action.spec.js
@@ -1,0 +1,44 @@
+context('with two actions', () => {
+  beforeEach(() => {
+    cy.task('createPlan', {
+      id: '1',
+      firstName: 'Bart',
+      lastName: 'Simpson',
+      queryFirstName: 'bart',
+      queryLastName: 'simpson',
+      goal: {
+        targetReviewDate: '2022-05-29T00:00:00.000Z',
+        text: 'This is a test goal',
+        useAsPhp: false,
+        actions: [
+          {
+            id: 'PPbqWA9',
+            summary: 'This is a test action',
+            description: 'This shall remain forever.',
+            dueDate: '2020-05-20',
+            isCompleted: true
+          },
+          {
+            id: 'hwX6aOr7',
+            summary: 'This is another test action',
+            description: 'We will delete this action in a test!',
+            dueDate: '2020-06-20',
+            isCompleted: false
+          }
+        ],
+        agreedWithName: 'Ami Working'
+      }
+    });
+
+    cy.setHackneyCookie(true);
+    cy.visit('http://localhost:3000/plans/1');
+  });
+
+  describe('clicking the delete button', () => {
+    it('deletes the action', () => {
+      const actionId = 'hwX6aOr7';
+      const selector = `[data-testid=actions-list-button-delete-${actionId}]`;
+      cy.get(selector).click().should('not.exist');
+    });
+  });
+});

--- a/cypress/integration/features/share-plan.spec.js
+++ b/cypress/integration/features/share-plan.spec.js
@@ -15,7 +15,7 @@ context('Share the plan with collaborator', () => {
       },
       numbers: ["070000000"],
       emails: ["example@plan.com"],
-      customerTokens: [{token: 'one', sharedDate: null}]
+      customerTokens: [{ token: 'one', sharedDate: null }]
     });
 
     cy.task('createPlan', {
@@ -57,11 +57,11 @@ context('Share the plan with collaborator', () => {
     cy.visit(`http://localhost:3000/plans/1`);
   },
 
-  afterEach(() => {
-    cy.task('deletePlan', '1');
-    cy.task('deletePlan', '2');
-    cy.task('deletePlan', '3');
-  });
+    afterEach(() => {
+      cy.task('deletePlan', '1');
+      cy.task('deletePlan', '2');
+      cy.task('deletePlan', '3');
+    });
 
   describe('Share the plan with resident', () => {
     it('Shares the plan via SMS', () => {
@@ -101,9 +101,9 @@ context('Share the plan with collaborator', () => {
       cy.get('[data-testid=share-link-to-plan-row-test] > span')
         .should('contain', 'Not yet shared with Bart');
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .should('contain', 'Share')
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .first()
         .click();
       cy.get('#content').should('contain', 'Last shared with');
@@ -115,55 +115,55 @@ context('Share the plan with collaborator', () => {
       cy.get('[data-testid=share-by-sms-row-test] > div > div > div > input')
         .click();
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
-      .first()
+      cy.get('[data-testid=share-plan-button]')
+        .first()
         .click();
 
       cy.get('#content').should('contain', 'Something went wrong. The plan could not be shared.');
     })
 
-    it ('Shows a warning when no sharing option is selected', () => {
+    it('Shows a warning when no sharing option is selected', () => {
       cy.visit('http://localhost:3000/plans/2/share');
 
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .first()
         .click();
 
       cy.get('#content').should('contain', 'Please select at least one sharing option');
     })
 
-    it ('Shows disabled checkbox when phone numbers do not exist', () => {
+    it('Shows disabled checkbox when phone numbers do not exist', () => {
       cy.visit('http://localhost:3000/plans/3/share');
 
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .first()
         .click();
 
       cy.get('#share-by-sms').should('be.disabled');
-      cy.get('[data-testid=share-by-sms-row-test]').should('contain','No numbers found.');
+      cy.get('[data-testid=share-by-sms-row-test]').should('contain', 'No numbers found.');
     })
 
-    it ('Shows disabled checkbox when emails do not exist', () => {
+    it('Shows disabled checkbox when emails do not exist', () => {
       cy.visit('http://localhost:3000/plans/3/share');
 
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .first()
         .click();
 
       cy.get('#share-by-email').should('be.disabled');
-      cy.get('[data-testid=share-by-email-row-test]').should('contain','No emails found.');
+      cy.get('[data-testid=share-by-email-row-test]').should('contain', 'No emails found.');
     })
 
     it('Shows a unique shareable link', () => {
       cy.visit('http://localhost:3000/plans/3/share');
 
-      cy.get('[data-testid=share-link-to-plan-row-test] > div > button')
+      cy.get('[data-testid=share-plan-button]')
         .last()
         .click();
 
-      cy.get('[data-testid=shareable-link_test]').should('contain','/c/plans/3?token=');
+      cy.get('[data-testid=shareable-link_test]').should('contain', '/c/plans/3?token=');
     })
-}
+  }

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -11,10 +11,15 @@ import { Button } from 'components/Form';
 import { getToken } from 'lib/utils/token';
 
 const PlanSummary = ({ planId, initialPlan, token }) => {
-  const { plan, loading, addGoal, addAction, updateAction, toggleAction } = usePlan(planId, {
-    initialPlan,
-    token
-  });
+  const {
+    plan,
+    loading,
+    addGoal,
+    addAction,
+    updateAction,
+    toggleAction,
+    deleteAction
+  } = usePlan(planId, { initialPlan, token });
 
   if (loading) {
     return <p>Loading...</p>;
@@ -52,6 +57,7 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
           actions={plan.goal?.actions || []}
           onEditAction={actionId => setEditActionId(actionId)}
           onActionToggled={toggleAction}
+          onActionDeleted={deleteAction}
         />
       )}
       {!editGoal && !showAddAction && (

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -7,7 +7,7 @@ import EditAction from 'components/Feature/EditAction';
 import ActionsList from 'components/Feature/ActionsList';
 import GoalSummary from 'components/Feature/GoalSummary';
 import LegalText from 'components/Feature/LegalText';
-import { Button } from 'components/Form';
+import { Button, ButtonGroup } from 'components/Form';
 import { getToken } from 'lib/utils/token';
 
 const PlanSummary = ({ planId, initialPlan, token }) => {
@@ -61,12 +61,21 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
         />
       )}
       {!editGoal && !showAddAction && (
-        <Button
-          data-testid="add-action-button"
-          text="Add action"
-          isSecondary={true}
-          onClick={() => setShowAddAction(true)}
-        />
+        <ButtonGroup>
+          <Button
+            data-testid="add-action-button"
+            text="Add action"
+            isSecondary={true}
+            onClick={() => setShowAddAction(true)}
+          />
+          <a
+            className="govuk-button"
+            href={`/plans/${planId}/share`}
+            data-testid="share-plan-button-test"
+          >
+            Share plan
+          </a>
+        </ButtonGroup>
       )}
       {!editGoal && showAddAction && (
         <AddAction
@@ -83,15 +92,6 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
             setEditActionId(false);
           }}
           action={plan.goal.actions.find(action => action.id === editActionId)} />
-      )}
-      {!editGoal && (
-        <a
-          className="govuk-button"
-          href={`/plans/${planId}/share`}
-          data-testid="share-plan-button-test"
-        >
-          Share plan
-        </a>
       )}
       {!editGoal && goal && goal.useAsPhp && <LegalText />}
     </>


### PR DESCRIPTION
**What**  
Adds a delete button to the `ActionsList` that is visible only to staff.

![image](https://user-images.githubusercontent.com/5405916/84669103-6106c480-af1c-11ea-84d4-8038d6cc664b.png)

**Why**  
So that we can remove actions if they are no longer required, or were added in error.

**Anything else?**  
 - Added a new `ButtonGroup` component that adds spacing between multiple buttons, removed the `form-group` wrapped around `Button` to allow buttons to appear next to one another.
 - This also fixes a minor bug where the "Edit action" button appeared for customers.