### PR TITLE
Fix customer link when sharing via SMS

### DIFF
--- a/components/Feature/SharePlan/index.js
+++ b/components/Feature/SharePlan/index.js
@@ -36,7 +36,7 @@ const SharePlan = ({ error, plan, customerUrl, onPlanShared }) => {
       setHasError(true);
       return;
     }
-    onPlanShared(selectedContact);
+    onPlanShared(selectedContact, customerUrl);
   };
 
   const getNumber = number => {

--- a/lib/use-cases/share-plan.js
+++ b/lib/use-cases/share-plan.js
@@ -1,4 +1,4 @@
-import { IsoDateTime } from '../../lib/domain/isodate';
+import { IsoDateTime } from 'lib/domain/isodate';
 
 export default class SharePlan {
   constructor({ planGateway, smsGateway }) {


### PR DESCRIPTION
**What**  
Fixed customer link to properly show when sharing via SMS, as it displayed "undefined" previously.

**Why**  
So the customer can see and access the link to their shared plan.

**Anything else?**  
 - Have you added any new third-party libraries? No.
 - Are any new environment variables or configuration values needed? No.
 - Anything else in this PR that isn't covered by the what/why? No.
