### PR TITLE
Fixes description width jumping around on expand

### DIFF
--- a/components/Feature/ActionsList/index.module.scss
+++ b/components/Feature/ActionsList/index.module.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.lbh-actions-list__complete {
+  width: 6rem;
+}
+
 .lbh-actions-list__description {
   h2 {
     margin-bottom: 0.25em;


### PR DESCRIPTION
**What**  
Fixes a bug where the width of the description column in the table would jump around depending on how much content it contains.

**Before**
![before_sp](https://user-images.githubusercontent.com/5405916/87922307-b3835580-ca73-11ea-8c6e-102cfebe10a6.gif)

**After**
![after_sp](https://user-images.githubusercontent.com/5405916/87922322-b9793680-ca73-11ea-868b-84c78d1e8e78.gif)

**Why**  
To avoid annoying behaviour when viewing shared plans.