### PR TITLE
Add hints to goal and action fields

### DIFF
--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -72,7 +72,7 @@ const AddAction = ({ onActionAdded, residentName, officerName }) => {
         </h3>
         <form onSubmit={addToPlan}>
           <TextInput
-            hint={`Example: '${residentName} to provide...' or '${officerName} to contact...'`}
+            hint={`Example: '${residentName} to provide...' or '${officerName?.split(" ")[0]} to contact...'`}
             name="summary-text"
             label="Action title"
             required

--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -3,7 +3,7 @@ import { DateInput, TextInput, Button, TextArea } from 'components/Form';
 import moment from 'moment';
 import css from './index.module.scss';
 
-const AddAction = ({ onActionAdded }) => {
+const AddAction = ({ onActionAdded, residentName, officerName }) => {
   const [summary, setActionSummary] = useState('');
   const [dueDate, setDueDate] = useState({ day: '', month: '', year: '' });
   const [description, setActionDescription] = useState('');
@@ -72,8 +72,9 @@ const AddAction = ({ onActionAdded }) => {
         </h3>
         <form onSubmit={addToPlan}>
           <TextInput
+            hint={`Example: '${residentName} to provide...' or '${officerName} to contact...'`}
             name="summary-text"
-            label="Summary"
+            label="Action title"
             required
             onChange={handleActionSummaryChange}
             validate={validate}
@@ -81,12 +82,14 @@ const AddAction = ({ onActionAdded }) => {
             value={summary}
           />
           <TextArea
+            hint="What you, or the resident will need to do to complete the action, including any required links, emails or phone numbers"
             name="full-description"
             label="Full description(optional)"
             onChange={handleActionDescriptionChange}
             value={description}
           />
           <DateInput
+            hint="Agreed date to complete the action"
             name="due-date"
             title="Due date"
             onChange={handleDueDateChange}

--- a/components/Feature/AddAction/index.test.js
+++ b/components/Feature/AddAction/index.test.js
@@ -6,7 +6,7 @@ describe('AddAction', () => {
   it('renders the add action form', () => {
     const { getByLabelText } = render(<AddAction />);
 
-    expect(getByLabelText('Summary')).toBeInTheDocument();
+    expect(getByLabelText('Action title')).toBeInTheDocument();
     expect(getByLabelText('Full description(optional)')).toBeInTheDocument();
     expect(getByLabelText('Day')).toBeInTheDocument();
     expect(getByLabelText('Month')).toBeInTheDocument();
@@ -20,7 +20,7 @@ describe('OnClick', () => {
     const { getByLabelText, getByText } = render(
       <AddAction onActionAdded={onActionAdded} />
     );
-    await userEvent.type(getByLabelText('Summary'), 'summary');
+    await userEvent.type(getByLabelText('Action title'), 'Action title');
     await userEvent.type(
       getByLabelText('Full description(optional)'),
       'description'
@@ -31,7 +31,7 @@ describe('OnClick', () => {
     await getByText('Add to plan').click();
 
     expect(onActionAdded).toHaveBeenCalledWith({
-      summary: 'summary',
+      summary: 'Action title',
       description: 'description',
       dueDate: expect.stringContaining('2200-01-01')
     });
@@ -43,7 +43,7 @@ describe('OnClick', () => {
       <AddAction onActionAdded={onActionAdded} />
     );
 
-    await userEvent.type(getByLabelText('Summary'), 'summary');
+    await userEvent.type(getByLabelText('Action title'), 'Action title');
     await userEvent.type(getByLabelText('Day'), '99');
     await userEvent.type(getByLabelText('Month'), '40000');
     await userEvent.type(getByLabelText('Year'), '0');

--- a/components/Feature/AddGoal/index.js
+++ b/components/Feature/AddGoal/index.js
@@ -77,7 +77,8 @@ const AddGoal = ({ goal, initialUseAsPhp, onGoalAdded }) => {
         <form onSubmit={addTheGoal}>
           <TextInput
             name="goal-text"
-            label="Goal"
+            label="Overall resident goal"
+            hint="Example: 'Find settled accommodation in the private rental sector' "
             onChange={handleGoalTextChange}
             validate={validate}
             autoComplete="off"
@@ -86,6 +87,7 @@ const AddGoal = ({ goal, initialUseAsPhp, onGoalAdded }) => {
           <DateInput
             name="target-review-date"
             title="Target review date"
+            hint="Your next appointment to review progress"
             onChange={handleTargetReviewDateChange}
             validate={validate}
             autoComplete="off"

--- a/components/Feature/AddGoal/index.test.js
+++ b/components/Feature/AddGoal/index.test.js
@@ -4,7 +4,7 @@ import AddGoal from './index';
 describe('AddGoal', () => {
   it('renders the add goal form', () => {
     const { getByLabelText, getByText } = render(<AddGoal plan={{ id: 1 }} />);
-    expect(getByLabelText('Goal')).toBeInTheDocument();
+    expect(getByLabelText('Overall resident goal')).toBeInTheDocument();
     expect(getByLabelText('Day')).toBeInTheDocument();
     expect(getByLabelText('Month')).toBeInTheDocument();
     expect(getByLabelText('Year')).toBeInTheDocument();
@@ -18,7 +18,7 @@ describe('AddGoal', () => {
       <AddGoal initialUseAsPhp={false} onGoalAdded={onGoalAdded} />
     );
 
-    fireEvent.change(getByLabelText('Goal'), {
+    fireEvent.change(getByLabelText('Overall resident goal'), {
       target: { value: 'this is my goal' }
     });
     fireEvent.change(getByLabelText('Day'), {
@@ -68,7 +68,7 @@ describe('AddGoal', () => {
 
   it('sets the goal input value if goal already exists', () => {
     const { getByLabelText } = render(<AddGoal goal={{ text: 'hello' }} />);
-    expect(getByLabelText('Goal').value).toEqual('hello');
+    expect(getByLabelText('Overall resident goal').value).toEqual('hello');
   });
 
   it('sets the target review date input value if goal already exists', () => {

--- a/components/Feature/EditAction/index.js
+++ b/components/Feature/EditAction/index.js
@@ -69,13 +69,17 @@ const EditAction = ({ action, onActionUpdated }) => {
   return (
     <div className={`govuk-grid-row ${css['row-add-new-action']}`}>
       <div className="govuk-grid-column-three-quarters">
-        <h3 className={`govuk-heading-m ${css['heading-add-new-action']}`} data-testsid="edit-action-heading-test">
+        <h3
+          className={`govuk-heading-m ${css['heading-add-new-action']}`}
+          data-testsid="edit-action-heading-test"
+        >
           Edit action
         </h3>
         <form onSubmit={updateAction}>
           <TextInput
             name="summary-text"
-            label="Summary"
+            label="Action title"
+            //hint={`Example: '${plan.firstName} to provide...' or '${label} to contact...'`}
             required
             onChange={handleActionSummaryChange}
             validate={validate}
@@ -83,14 +87,16 @@ const EditAction = ({ action, onActionUpdated }) => {
             value={summary}
           />
           <TextArea
+            hint="What you, or the resident will need to do to complete the action, including any required links, emails or phone numbers"
             name="full-description"
-            label="Full description(optional)"
+            label="Full description (optional)"
             onChange={handleActionDescriptionChange}
             value={description}
           />
           <DateInput
             name="due-date"
             title="Due date"
+            hint="Agreed date to complete the action"
             onChange={handleDueDateChange}
             validate={validate}
             autoComplete="off"

--- a/components/Feature/EditAction/index.js
+++ b/components/Feature/EditAction/index.js
@@ -3,7 +3,7 @@ import { DateInput, TextInput, Button, TextArea } from 'components/Form';
 import moment from 'moment';
 import css from './index.module.scss';
 
-const EditAction = ({ action, onActionUpdated }) => {
+const EditAction = ({ action, onActionUpdated, residentName, officerName }) => {
   const [year, month, day] = action.dueDate.split('-');
   const [summary, setActionSummary] = useState(action.summary);
   const [dueDate, setDueDate] = useState({ day, month, year });
@@ -77,9 +77,9 @@ const EditAction = ({ action, onActionUpdated }) => {
         </h3>
         <form onSubmit={updateAction}>
           <TextInput
+            hint={`Example: '${residentName} to provide...' or '${officerName} to contact...'`}
             name="summary-text"
             label="Action title"
-            //hint={`Example: '${plan.firstName} to provide...' or '${label} to contact...'`}
             required
             onChange={handleActionSummaryChange}
             validate={validate}
@@ -94,9 +94,9 @@ const EditAction = ({ action, onActionUpdated }) => {
             value={description}
           />
           <DateInput
+            hint="Agreed date to complete the action"
             name="due-date"
             title="Due date"
-            hint="Agreed date to complete the action"
             onChange={handleDueDateChange}
             validate={validate}
             autoComplete="off"

--- a/components/Feature/EditAction/index.test.js
+++ b/components/Feature/EditAction/index.test.js
@@ -6,8 +6,8 @@ describe('EditAction', () => {
   it('renders the edit action form', () => {
     const { getByLabelText } = render(<EditAction action={{dueDate: '2025-11-28'}} />);
 
-    expect(getByLabelText('Summary')).toBeInTheDocument();
-    expect(getByLabelText('Full description(optional)')).toBeInTheDocument();
+    expect(getByLabelText('Action title')).toBeInTheDocument();
+    expect(getByLabelText('Full description (optional)')).toBeInTheDocument();
     expect(getByLabelText('Day')).toBeInTheDocument();
     expect(getByLabelText('Month')).toBeInTheDocument();
     expect(getByLabelText('Year')).toBeInTheDocument();
@@ -20,11 +20,11 @@ describe('OnClick', () => {
     const { getByLabelText, getByTestId } = render(
       <EditAction action={{dueDate: '2200-01-01', description: 'description', summary: 'summary'}} onActionUpdated={onActionUpdated} />
     );
-    await userEvent.clear(getByLabelText('Summary'));
-    await userEvent.type(getByLabelText('Summary'), 'summary');
-    await userEvent.clear(getByLabelText('Full description(optional)'));
+    await userEvent.clear(getByLabelText('Action title'));
+    await userEvent.type(getByLabelText('Action title'), 'Action title');
+    await userEvent.clear(getByLabelText('Full description (optional)'));
     await userEvent.type(
-      getByLabelText('Full description(optional)'),
+      getByLabelText('Full description (optional)'),
       'description'
     );
     await userEvent.clear(getByLabelText('Day'));
@@ -36,7 +36,7 @@ describe('OnClick', () => {
     await getByTestId('save-action-button-test').click();
 
     expect(onActionUpdated).toHaveBeenCalledWith({
-      summary: 'summary',
+      summary: 'Action title',
       description: 'description',
       dueDate: expect.stringContaining('2200-01-01')
     });
@@ -48,8 +48,8 @@ describe('OnClick', () => {
       <EditAction action={{description: 'description', summary: 'summary', dueDate: '2025-11-28'}} onActionUpdated={onActionUpdated} />
     );
 
-    await userEvent.clear(getByLabelText('Summary'));
-    await userEvent.type(getByLabelText('Summary'), 'summary');
+    await userEvent.clear(getByLabelText('Action title'));
+    await userEvent.type(getByLabelText('Action title'), 'Action title');
     await userEvent.clear(getByLabelText('Day'));
     await userEvent.type(getByLabelText('Day'), '99');
     await userEvent.clear(getByLabelText('Month'));

--- a/components/Form/DateInput/index.js
+++ b/components/Form/DateInput/index.js
@@ -4,6 +4,7 @@ import moment from 'moment';
 const DateInput = ({
   autoComplete,
   day,
+  hint,
   month,
   name,
   onChange,
@@ -40,9 +41,14 @@ const DateInput = ({
           <h3 className="govuk-label">{title}</h3>
         </legend>
 
-        {showHint && (
-          <span id={`${name}-hint`} className="govuk-hint">
-            For example, 12 10 2025
+        {/*{showHint && (*/}
+        {/*  <span id={`${name}-hint`} className="govuk-hint">*/}
+        {/*    For example, 12 10 2025*/}
+        {/*  </span>*/}
+        {/*)}*/}
+        {hint && (
+          <span id={`${name}-hint`} className={'govuk-hint'}>
+            {hint}
           </span>
         )}
 

--- a/components/Form/DateInput/index.js
+++ b/components/Form/DateInput/index.js
@@ -9,7 +9,6 @@ const DateInput = ({
   name,
   onChange,
   required = true,
-  showHint,
   title,
   validate,
   year
@@ -33,7 +32,7 @@ const DateInput = ({
       <fieldset
         className="govuk-fieldset"
         role="group"
-        aria-describedby={`${showHint ? `${name}-hint` : ''}${
+        aria-describedby={`${hint ? `${name}-hint` : ''}${
           hasError ? ` ${name}-error` : ''
         }`}
       >
@@ -41,11 +40,6 @@ const DateInput = ({
           <h3 className="govuk-label">{title}</h3>
         </legend>
 
-        {/*{showHint && (*/}
-        {/*  <span id={`${name}-hint`} className="govuk-hint">*/}
-        {/*    For example, 12 10 2025*/}
-        {/*  </span>*/}
-        {/*)}*/}
         {hint && (
           <span id={`${name}-hint`} className={'govuk-hint'}>
             {hint}

--- a/components/Form/DateInput/index.test.js
+++ b/components/Form/DateInput/index.test.js
@@ -41,9 +41,9 @@ describe('DateInput', () => {
     expect(title).toBeInTheDocument();
   });
 
-  it('renders a hint if showHint is true', () => {
+  it('renders a hint if a hint was provided', () => {
     const { container } = render(
-      <DateInput name={inputName} showHint={true} />
+      <DateInput name={inputName} hint="Agreed date" />
     );
     const hint = container.querySelector(`#${inputName}-hint`);
 

--- a/components/Form/TextArea/index.js
+++ b/components/Form/TextArea/index.js
@@ -1,8 +1,13 @@
-const TextArea = ({ label, name, onChange, value }) => (
+const TextArea = ({ hint, label, name, onChange, value }) => (
   <div className="govuk-form-group">
     <label className="govuk-label" htmlFor={`${name}`}>
       {label}
     </label>
+    {hint && (
+      <span id={`${name}-hint`} className={'govuk-hint'}>
+        {hint}
+      </span>
+    )}
     <textarea
       className="govuk-textarea"
       id={name}

--- a/components/Form/TextInput/index.js
+++ b/components/Form/TextInput/index.js
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 
-const TextInput = ({ label, name, onChange, validate, value, autoComplete }) => {
+const TextInput = ({
+  hint,
+  label,
+  name,
+  onChange,
+  validate,
+  value,
+  autoComplete
+}) => {
   const [hasError, setHasError] = useState(false);
   useEffect(() => {
     if (validate) setHasError(!value);
@@ -15,6 +23,12 @@ const TextInput = ({ label, name, onChange, validate, value, autoComplete }) => 
       <label className="govuk-label" htmlFor={name}>
         {label}
       </label>
+
+      {hint && (
+        <span id={`${name}-hint`} className="govuk-hint">
+          {hint}
+        </span>
+      )}
       {hasError && (
         <span id={`${name}-error`} className="govuk-error-message">
           <span className="govuk-visually-hidden">Error:</span> The {label} is

--- a/components/Form/TextInput/index.js
+++ b/components/Form/TextInput/index.js
@@ -7,7 +7,7 @@ const TextInput = ({
   onChange,
   validate,
   value,
-  autoComplete
+  autoComplete,
 }) => {
   const [hasError, setHasError] = useState(false);
   useEffect(() => {

--- a/cypress/integration/features/add-action.spec.js
+++ b/cypress/integration/features/add-action.spec.js
@@ -132,12 +132,12 @@ context('Add action form', () => {
       cy.get('[data-testid=details-summary]').should('not.exist');
     });
 
-    it('Shows a validation error when the summary text is empty', () => {
+    it('Shows a validation error when the action title text is empty', () => {
       createAction('', 'Action description', '1', '2', '2021');
       cy.get('[data-testid=add-action-button-test]').click();
       cy.get('#summary-text-error').should(
         'contain',
-        'The Summary is required'
+        'The Action title is required'
       );
     });
 

--- a/cypress/integration/features/add-goal.spec.js
+++ b/cypress/integration/features/add-goal.spec.js
@@ -75,10 +75,10 @@ context('Add-goal form', () => {
       );
     });
 
-    it('Shows a validation error when the goal text is empty', () => {
+    it('Shows a validation error when the overall resident goal text is empty', () => {
       createGoal('', '8', '11', '2025', false);
       cy.get('[data-testid=add-actions-button-test]').click();
-      cy.get('#goal-text-error').should('contain', 'The Goal is required');
+      cy.get('#goal-text-error').should('contain', 'The Overall resident goal is required');
     });
 
     it('Shows validation error when the day is empty', () => {

--- a/pages/plans/[id].js
+++ b/pages/plans/[id].js
@@ -83,6 +83,8 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
             await addAction(action);
             setShowAddAction(false);
           }}
+          officerName={goal.agreedWithName}
+          residentName={plan.firstName}
         />
       )}
       {editActionId && (
@@ -91,6 +93,8 @@ const PlanSummary = ({ planId, initialPlan, token }) => {
             await updateAction(action);
             setEditActionId(false);
           }}
+          officerName={goal.agreedWithName}
+          residentName={plan.firstName}
           action={plan.goal.actions.find(action => action.id === editActionId)} />
       )}
       {!editGoal && goal && goal.useAsPhp && <LegalText />}

--- a/pages/plans/[id].test.js
+++ b/pages/plans/[id].test.js
@@ -40,7 +40,7 @@ describe('PlanSummary', () => {
     it('renders the add goal form if goal is falsy', () => {
       const plan = { id: '1', firstName: 'John', lastName: 'Musk' };
       const { getByLabelText } = render(<PlanSummary initialPlan={plan} />);
-      expect(getByLabelText('Goal')).toBeInTheDocument();
+      expect(getByLabelText('Overall resident goal')).toBeInTheDocument();
     });
 
     it('renders the legal text if useAsPhp is true', () => {


### PR DESCRIPTION
**What**  
Added hints for each form input for goal and action.

<img width="771" alt="image" src="https://user-images.githubusercontent.com/54269120/87922409-df9ed680-ca73-11ea-8de2-94e77d52ca93.png">

<img width="741" alt="image" src="https://user-images.githubusercontent.com/54269120/87922515-02c98600-ca74-11ea-9a8e-87e210912fcb.png">


**Why**  
So that users have a better understanding of what that field is about and to guide them to fill in the correct information.

**Anything else?**  
 - Have you added any new third-party libraries? No.
 - Are any new environment variables or configuration values needed? No.
 - Anything else in this PR that isn't covered by the what/why? No.
