### PR TITLE
Display collaborators in mobile view

### DIFF
--- a/components/Feature/SharePlan/index.module.scss
+++ b/components/Feature/SharePlan/index.module.scss
@@ -10,6 +10,11 @@
 }
 
 .share-plan__table {
+  thead {
+    @media (max-width: #{$screen-sm-min}) {
+      display: none;
+    }
+  }
   tr {
     td,
     th {
@@ -17,12 +22,10 @@
     }
   }
 }
-
 .share-plan__collaborators-list {
   width: 12rem;
-
   @media (max-width: #{$screen-sm-min}) {
-    display: none;
+    display: inline;
   }
 }
 


### PR DESCRIPTION
**What**
Get collaborators to display on mobile view:

<img width="301" alt="image" src="https://user-images.githubusercontent.com/54268893/88042763-5f947180-cb44-11ea-8c7e-2e5651118b00.png">

**Why**
To allow mobile view