### PR TITLE
Remove unused role statements from serverless

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ A tool that helps create a shared plan of action between a Hackney resident and 
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the home page.
 
+## AWS permissions
+
+In order to schedule reminders, sls deploy requires EventBridge permissions.
+EventBridge permissions can be set in AWS management console > Identity and Access Management (IAM) > Policies.
+
 ## Unit tests
 
 Run jest tests:

--- a/README.md
+++ b/README.md
@@ -1,36 +1,47 @@
 # Shared Plan
+
 A tool that helps create a shared plan of action between a Hackney resident and the professionals supporting them.
 
 ## Getting Started
 
 1. Install dependencies:
-  ```bash
-  yarn
-  ```
+
+```bash
+yarn
+```
 
 2. Create a .env file, based on the .env.sample file:
-  ```bash
-  touch .env # then go fill it in!
-  ```
+
+```bash
+touch .env # then go fill it in!
+```
 
 3. Set up DynamoDB local:
-  Install Java if you don't already have it
-  Install dynamodb:
-  ```bash
-  sls dynamodb install
-  ```
+   Install Java if you don't already have it
+   Install dynamodb:
+
+```bash
+sls dynamodb install
+```
 
 4. Create local DynamoDB plans table:
-  ```bash
-  aws dynamodb create-table --cli-input-json file://./config/tables/plans.json --endpoint-url http://localhost:8000
-  ```
+
+```bash
+aws dynamodb create-table --cli-input-json file://./config/tables/plans.json --endpoint-url http://localhost:8000
+```
 
 5. Run the development server:
-  ```bash
-  yarn dev
-  ```
+
+```bash
+yarn dev
+```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the home page.
+
+## AWS permissions
+
+In order to schedule reminders sls deploy requires EventBridge permissions set for ServerlessDeployer.
+EventBridge permissions can be set in AWS management console > Identity and Access Management (IAM) > Policies.
 
 ## Unit tests
 
@@ -44,67 +55,70 @@ yarn unit-test
 
 Set these env vars in .env file:
 
-  NEXT_PUBLIC_API_URL=http://localhost:3000/api  
-  SMS_API_URL=http://localhost:8080
-
+NEXT_PUBLIC_API_URL=http://localhost:3000/api  
+ SMS_API_URL=http://localhost:8080
 
 #### Run cypress integration tests headlessly:
+
 1. Set these env vars to the same values as your local aws cli config:
 
-  CYPRESS_AWS_ACCESS_KEY_ID  
-  CYPRESS_AWS_SECRET_ACCESS_KEY  
-  CYPRESS_AWS_REGION  
-
+CYPRESS_AWS_ACCESS_KEY_ID  
+ CYPRESS_AWS_SECRET_ACCESS_KEY  
+ CYPRESS_AWS_REGION
 
 2. Run the tests:
-  ```bash
-  yarn run int-test
-  ```
+
+```bash
+yarn run int-test
+```
 
 #### Run tests in cypress test runner:
+
 1. Start shared-plan and mock-sms servers:
-  ```bash
-  yarn start-cypress-servers
-  ```
+
+```bash
+yarn start-cypress-servers
+```
 
 2. Open the test runner:
-  ```bash
-  yarn cypress-open
-  ```
+
+```bash
+yarn cypress-open
+```
 
 ## Pages
+
 Home page:  
-  /
+ /
 
 Plan summary:  
-  /plans/[id]
+ /plans/[id]
 
 Sharing page of the plan:  
-  /plan/[id]/share
-
+ /plan/[id]/share
 
 ## Api routes
 
 Create a shared plan:  
-  /plans
+ /plans
 
 Get the shared plan:  
-  /plans/[id]
+ /plans/[id]
 
 Add goals to the shared plan:  
-  /plans/[id]/goals
+ /plans/[id]/goals
 
 Add actions to the shared plan:  
-  /plans/[id]/actions
+ /plans/[id]/actions
 
 Update and delete an action:  
-  /plans/[id]/actions/[actionId]
+ /plans/[id]/actions/[actionId]
 
 Share the plan with collaborator:  
-  /plans/[id]/share
+ /plans/[id]/share
 
 Create/get shareable customer url:  
-  /plans/[id]/customerUrl
+ /plans/[id]/customerUrl
 
 Find the shared plan with correct name and system IDs:  
-  /plans/[id]/find
+ /plans/[id]/find

--- a/README.md
+++ b/README.md
@@ -1,47 +1,36 @@
 # Shared Plan
-
 A tool that helps create a shared plan of action between a Hackney resident and the professionals supporting them.
 
 ## Getting Started
 
 1. Install dependencies:
-
-```bash
-yarn
-```
+  ```bash
+  yarn
+  ```
 
 2. Create a .env file, based on the .env.sample file:
-
-```bash
-touch .env # then go fill it in!
-```
+  ```bash
+  touch .env # then go fill it in!
+  ```
 
 3. Set up DynamoDB local:
-   Install Java if you don't already have it
-   Install dynamodb:
-
-```bash
-sls dynamodb install
-```
+  Install Java if you don't already have it
+  Install dynamodb:
+  ```bash
+  sls dynamodb install
+  ```
 
 4. Create local DynamoDB plans table:
-
-```bash
-aws dynamodb create-table --cli-input-json file://./config/tables/plans.json --endpoint-url http://localhost:8000
-```
+  ```bash
+  aws dynamodb create-table --cli-input-json file://./config/tables/plans.json --endpoint-url http://localhost:8000
+  ```
 
 5. Run the development server:
-
-```bash
-yarn dev
-```
+  ```bash
+  yarn dev
+  ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the home page.
-
-## AWS permissions
-
-In order to schedule reminders sls deploy requires EventBridge permissions set for ServerlessDeployer.
-EventBridge permissions can be set in AWS management console > Identity and Access Management (IAM) > Policies.
 
 ## Unit tests
 
@@ -55,70 +44,67 @@ yarn unit-test
 
 Set these env vars in .env file:
 
-NEXT_PUBLIC_API_URL=http://localhost:3000/api  
- SMS_API_URL=http://localhost:8080
+  NEXT_PUBLIC_API_URL=http://localhost:3000/api  
+  SMS_API_URL=http://localhost:8080
+
 
 #### Run cypress integration tests headlessly:
-
 1. Set these env vars to the same values as your local aws cli config:
 
-CYPRESS_AWS_ACCESS_KEY_ID  
- CYPRESS_AWS_SECRET_ACCESS_KEY  
- CYPRESS_AWS_REGION
+  CYPRESS_AWS_ACCESS_KEY_ID  
+  CYPRESS_AWS_SECRET_ACCESS_KEY  
+  CYPRESS_AWS_REGION  
+
 
 2. Run the tests:
-
-```bash
-yarn run int-test
-```
+  ```bash
+  yarn run int-test
+  ```
 
 #### Run tests in cypress test runner:
-
 1. Start shared-plan and mock-sms servers:
-
-```bash
-yarn start-cypress-servers
-```
+  ```bash
+  yarn start-cypress-servers
+  ```
 
 2. Open the test runner:
-
-```bash
-yarn cypress-open
-```
+  ```bash
+  yarn cypress-open
+  ```
 
 ## Pages
-
 Home page:  
- /
+  /
 
 Plan summary:  
- /plans/[id]
+  /plans/[id]
 
 Sharing page of the plan:  
- /plan/[id]/share
+  /plan/[id]/share
+
 
 ## Api routes
 
 Create a shared plan:  
- /plans
+  /plans
 
 Get the shared plan:  
- /plans/[id]
+  /plans/[id]
 
 Add goals to the shared plan:  
- /plans/[id]/goals
+  /plans/[id]/goals
 
 Add actions to the shared plan:  
- /plans/[id]/actions
+  /plans/[id]/actions
 
 Update and delete an action:  
- /plans/[id]/actions/[actionId]
+  /plans/[id]/actions/[actionId]
 
 Share the plan with collaborator:  
- /plans/[id]/share
+  /plans/[id]/share
 
 Create/get shareable customer url:  
- /plans/[id]/customerUrl
+  /plans/[id]/customerUrl
 
 Find the shared plan with correct name and system IDs:  
- /plans/[id]/find
+  /plans/[id]/find

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,11 +16,6 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-        - events:putRule
-        - events:putTargets
-        - events:deleteRule
-        - events:removeTargets
-        - events:TagResource
       Resource: '*'
 
 package:


### PR DESCRIPTION
**What**  
Remove unused role statements from serverless

**Why**  
Adding those roles didn't have impact on the permissions for EventBridge. Instead added roles manually in AWS