### PR TITLE
Updates due date validation to allow today or past dates

### DIFF
--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -40,7 +40,7 @@ const AddAction = ({ onActionAdded, residentName, officerName }) => {
       `${dueDate.day}-${dueDate.month}-${dueDate.year}`,
       'DD-MM-YYYY'
     );
-    return summary && date.isValid() && date.isAfter();
+    return summary && date.isValid() && date.isSameOrAfter();
   };
 
   const addToPlan = event => {

--- a/components/Feature/AddAction/index.js
+++ b/components/Feature/AddAction/index.js
@@ -40,7 +40,7 @@ const AddAction = ({ onActionAdded, residentName, officerName }) => {
       `${dueDate.day}-${dueDate.month}-${dueDate.year}`,
       'DD-MM-YYYY'
     );
-    return summary && date.isValid() && date.isSameOrAfter();
+    return summary && date.isValid() && date.isSameOrAfter(moment(), 'date');
   };
 
   const addToPlan = event => {

--- a/components/Feature/EditAction/index.js
+++ b/components/Feature/EditAction/index.js
@@ -47,7 +47,7 @@ const EditAction = ({ action, onActionUpdated, residentName, officerName }) => {
       `${dueDate.day}-${dueDate.month}-${dueDate.year}`,
       'DD-MM-YYYY'
     );
-    return summary && date.isValid() && date.isAfter();
+    return summary && date.isValid();
   };
 
   const updateAction = event => {

--- a/cypress/integration/features/add-action.spec.js
+++ b/cypress/integration/features/add-action.spec.js
@@ -177,6 +177,23 @@ context('Add action form', () => {
       );
     });
 
+    it('Does not show an error when the date is today', () => {
+      const today = new Date(Date.now());
+      createAction(
+        'Action summary',
+        'Action description',
+        today.getDate(),
+        today.getMonth() + 1,
+        today.getFullYear()
+      );
+
+      cy.get('[data-testid=add-action-button-test]').click();
+      cy.get('#due-date-error').should(
+        'not.contain',
+        'The Due date must be valid and in the future'
+      );
+    });
+
     it('Checks the form is hidden after adding an action', () => {
       createAction('Action summary', 'Action description', '4', '12', '2025');
       cy.get('[data-testid=add-action-button-test]').click();


### PR DESCRIPTION
**What**  
Allows todays date as a due date when creating actions, allows any valid date (including dates in the past) when editing actions.

**Why**  
So that actions can be created for the current day and so that actions can be edited after their due date has passed.

**Anything else?**  
 - Have you added any new third-party libraries? No.
 - Are any new environment variables or configuration values needed? No. 
 - Anything else in this PR that isn't covered by the what/why? No.
